### PR TITLE
Refine oscilloscope preview and ribbon renderer

### DIFF
--- a/Tenney/LissajousMetalView.swift
+++ b/Tenney/LissajousMetalView.swift
@@ -1,0 +1,48 @@
+//
+//  LissajousMetalView.swift
+//  Tenney
+//
+//  Shared MTKView bridge for Lissajous renderer previews.
+//
+
+import Foundation
+import MetalKit
+import SwiftUI
+
+struct LissajousMetalView: UIViewRepresentable {
+    let theme: LatticeTheme
+    let rootHz: Double
+    var pair: (RatioResult, RatioResult) = (.init(num: 1, den: 1, octave: 0),
+                                            .init(num: 1, den: 1, octave: 0))
+    let config: LissajousRenderer.Config
+
+    func makeUIView(context: Context) -> MTKView {
+        let v = MTKView()
+        v.isPaused = false
+        v.enableSetNeedsDisplay = false
+        v.preferredFramesPerSecond = config.preferredFPS
+        context.coordinator.attach(to: v)
+        return v
+    }
+
+    func updateUIView(_ uiView: MTKView, context: Context) {
+        uiView.preferredFramesPerSecond = config.preferredFPS
+        let r = context.coordinator.renderer!
+        r.setTheme(theme)
+        r.setRatios(
+            x: .init(num: pair.0.num, den: pair.0.den, octave: pair.0.octave),
+            y: .init(num: pair.1.num, den: pair.1.den, octave: pair.1.octave),
+            rootHz: rootHz
+        )
+        r.setConfig { $0 = config } // apply full config atomically
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+    final class Coordinator: NSObject {
+        var renderer: LissajousRenderer?
+        func attach(to view: MTKView) {
+            renderer = LissajousRenderer(mtkView: view)
+            view.delegate = renderer
+        }
+    }
+}

--- a/Tenney/LissajousShaders.metal
+++ b/Tenney/LissajousShaders.metal
@@ -21,6 +21,12 @@ struct Uniforms {
     float2 pan;
     float  alpha;
     float  pointSize;   // used in dot mode
+    float  ribbonWidth;
+    float  globalAlpha;
+    float  edgeAA;
+    float  _pad;
+    float4 coreColor;
+    float4 sheenColor;
 };
 
 // ---- Line / Point pass ------------------------------------------------------
@@ -43,6 +49,47 @@ vertex Varyings lissa_vtx(uint vid [[vertex_id]],
 
 fragment float4 lissa_frag(Varyings in [[stage_in]]) {
     return in.color; // premultiplied not required; blending configured in Swift
+}
+
+// ---- Ribbon pass -----------------------------------------------------------
+struct RibbonVSIn {
+    float2 pos;
+    float2 normal;
+    float  side;
+    float  u;
+};
+
+struct RibbonVaryings {
+    float4 position [[position]];
+    float  side;
+    float  u;
+};
+
+vertex RibbonVaryings lissa_ribbon_vtx(uint vid [[vertex_id]],
+                                       const device RibbonVSIn* vtx [[buffer(0)]],
+                                       constant Uniforms& U        [[buffer(1)]]) {
+    RibbonVaryings o;
+    float2 p = vtx[vid].pos;
+    float2 n = vtx[vid].normal;
+    float s  = vtx[vid].side;
+    float width = max(0.1f, U.ribbonWidth);
+    float2 offset = n * (0.5f * width * s);
+    float2 world = (p + offset) * U.scale + U.pan;
+    o.position = float4(world, 0.0, 1.0);
+    o.side = s;
+    o.u = vtx[vid].u;
+    return o;
+}
+
+fragment float4 lissa_ribbon_frag(RibbonVaryings in [[stage_in]],
+                                  constant Uniforms& U [[buffer(1)]]) {
+    float mixv = smoothstep(0.0, 1.0, in.u);
+    float4 col = mix(U.coreColor, U.sheenColor, mixv);
+    float coverage = clamp((1.0 - fabs(in.side)) / max(0.0001, U.edgeAA), 0.0, 1.0);
+    float alpha = U.globalAlpha * coverage;
+    col.rgb *= alpha;
+    col.a = alpha;
+    return col;
 }
 
 // ---- Fullscreen quad for persistence / blit ---------------------------------
@@ -72,4 +119,3 @@ fragment float4 blit_frag(QuadVSOut in [[stage_in]],
                           sampler s            [[sampler(0)]]) {
     return tex.sample(s, in.uv);
 }
-

--- a/Tenney/SettingsKeys+Oscilloscope.swift
+++ b/Tenney/SettingsKeys+Oscilloscope.swift
@@ -1,0 +1,24 @@
+//
+//  SettingsKeys+Oscilloscope.swift
+//  Tenney
+//
+//  Created by ChatGPT on 3/7/24.
+//
+
+import Foundation
+
+extension SettingsKeys {
+    static let lissaSamples      = "Lissa.samples"
+    static let lissaGridDivs     = "Lissa.gridDivs"
+    static let lissaShowGrid     = "Lissa.showGrid"
+    static let lissaShowAxes     = "Lissa.showAxes"
+    static let lissaStrokeWidth  = "Lissa.strokeWidth"
+    static let lissaDotMode      = "Lissa.dotMode"
+    static let lissaDotSize      = "Lissa.dotSize"
+    static let lissaPersistence  = "Lissa.persistence"
+    static let lissaHalfLife     = "Lissa.halfLife"
+    static let lissaSnap         = "Lissa.snap"
+    static let lissaMaxDen       = "Lissa.maxDen"
+    static let lissaLiveSamples  = "Lissa.liveSamples"
+    static let lissaGlobalAlpha  = "Lissa.globalAlpha"
+}


### PR DESCRIPTION
## Summary
- add shared oscilloscope settings keys and a reusable Metal preview bridge
- move oscilloscope controls into Settings with a live preview while simplifying the card to preview-only
- switch oscilloscope rendering to a premultiplied ribbon pipeline with accessibility-aware defaults

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951956e504c8327a15330f8cd16fa39)