### PR TITLE
Fix live ribbon counts and widen builder oscilloscope

### DIFF
--- a/Tenney/ScaleBuilderScreen.swift
+++ b/Tenney/ScaleBuilderScreen.swift
@@ -387,25 +387,24 @@ struct ScaleBuilderScreen: View {
         private var pads: some View {
             // Large tap zones for performance; two columns by default
             ScrollView {
-                LazyVGrid(
-                    columns: [
-                        GridItem(.flexible(minimum: 140), spacing: 10),
-                        GridItem(.flexible(minimum: 140), spacing: 10)
-                    ],
-                    spacing: 10
-                ) {
-                    // Lissajous oscilloscope (spans both columns)
+                VStack(spacing: 10) {
                     LissajousCard(
                         activeSignals: scopeSignals,
                         rootHz: store.payload.rootHz
                     )
-
-                    .frame(minHeight: 220)                // iPhone; grows on iPad naturally
-                    .gridCellColumns(2)                   // span both columns
+                    .frame(maxWidth: .infinity, minHeight: 220)
                     .accessibilityIdentifier("LissajousCard")
-                    
-                    ForEach(Array(store.degrees.enumerated()), id: \.offset) { idx, r in
-                        padButton(idx: idx, r: r)
+
+                    LazyVGrid(
+                        columns: [
+                            GridItem(.flexible(minimum: 140), spacing: 10),
+                            GridItem(.flexible(minimum: 140), spacing: 10)
+                        ],
+                        spacing: 10
+                    ) {
+                        ForEach(Array(store.degrees.enumerated()), id: \.offset) { idx, r in
+                            padButton(idx: idx, r: r)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- track live snapshot point and ribbon counts to avoid drawing with insufficient vertices in live mode
- guard live and synthetic draw calls using computed counts so triangle strips and point draws only fire when populated
- move the builder Lissajous card outside the grid so the oscilloscope spans the available width

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69519d68a3c88327ae199cdeda7b272c)