### PR TITLE
Improve Mac Catalyst tuner rail splitter and visibility controls

### DIFF
--- a/Tenney/AppModel.swift
+++ b/Tenney/AppModel.swift
@@ -87,6 +87,7 @@ final class AppModel: ObservableObject {
     }
     /// Controls showing the onboarding wizard as a liquid-glass modal overlay.
     @Published var showOnboardingWizard: Bool = false
+    @Published var openSettingsToTunerRail: Bool = false
     // Lattice audition state (UtilityBar ↔ LatticeScreen sync)
     @Published var latticeAuditionOn: Bool = false
     // Library detent presentation


### PR DESCRIPTION
## Summary
- drive the tuner rail show/hide flow from AppStorage with a tuner-stage context menu for re-enabling the rail
- fix the Catalyst tuner rail splitter with persistent clamped widths, hover feedback, and independent scrolling content
- add a settings deep-link flag to open the tuner rail preferences when customizing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958135379f083279d88b96d13107d8e)