### PR TITLE
Fix tuner rail compile errors

### DIFF
--- a/Tenney/SettingsKeys.swift
+++ b/Tenney/SettingsKeys.swift
@@ -132,6 +132,8 @@ enum SettingsKeys {
     static let tunerRailPresetsJSON     = "tenney.tunerRail.presetsJSON"
     static let tunerRailIntervalTapeMs  = "tenney.tunerRail.intervalTape.ms"
     static let tunerRailMiniLatticeLimit = "tenney.tunerRail.miniLattice.primeLimit"
+    static let railMiniLatticePrimeLimit = tunerRailMiniLatticeLimit
+    static let railMiniLatticeAxisShift  = "tenney.tunerRail.miniLattice.axisShift"
     
     // Audio Settings
        static let audioPreferredInputPortUID = "tenney.audio.preferredInputPortUID"


### PR DESCRIPTION
## Summary
- fix tuner rail ratio parsing and mini lattice settings keys
- move nearest-target refresh helper out of view builder and add candidate solver helper
- add ratio candidate support in RatioSolver for nearest target lists

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958475af25c8327ac6bef21dfc6bab8)