### PR TITLE
Fix tuner rail compilation hooks

### DIFF
--- a/Tenney/TunerRailCards.swift
+++ b/Tenney/TunerRailCards.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import Combine
 import CoreGraphics
+import UIKit
 
 // MARK: - Shared rail models / helpers
 
@@ -804,12 +805,12 @@ struct TunerContextRailHost: View {
             TunerRailNearestTargetsCard(
                 snapshot: clock.snapshot,
                 rootHz: app.rootHz,
-                primeLimit: app.primeLimit,
+                primeLimit: globalPrimeLimit,
                 axisShift: globalAxisShift,
                 session: session,
                 onLock: onLockTarget,
                 onExportSingleToScale: { ref in
-                    let payload = ScaleBuilderPayload(rootHz: app.rootHz, primeLimit: app.primeLimit, items: [ref])
+                    let payload = ScaleBuilderPayload(rootHz: app.rootHz, primeLimit: globalPrimeLimit, items: [ref])
                     onExportScale(payload)
                 },
                 collapsed: binding(for: id)
@@ -820,7 +821,7 @@ struct TunerContextRailHost: View {
                 snapshot: clock.snapshot,
                 session: session,
                 rootHz: app.rootHz,
-                primeLimit: app.primeLimit,
+                primeLimit: globalPrimeLimit,
                 onExportScale: onExportScale,
                 onLock: onLockTarget,
                 collapsed: binding(for: id)


### PR DESCRIPTION
## Summary
- share a single TunerStore across ContentView and the tuner rail to drive lock target actions
- load a lattice axis shift snapshot and pass global prime limit/export handlers into TunerContextRailHost
- align tuner rail cards with the shared prime limit and add UIKit import for Catalyst pasteboard access

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69584d53bdfc83278cb53030ec60e2cd)