### PR TITLE
Add tuner root override and stabilize mini lattice

### DIFF
--- a/Tenney/ContentView.swift
+++ b/Tenney/ContentView.swift
@@ -807,7 +807,7 @@ extension Notification.Name {
                 // Chrono dial (rectangular card contains it)
                 let rawCents: Double = {
                     if let locked = store.lockedTarget {
-                        return signedCents(actualHz: liveHz, rootHz: model.rootHz, target: locked)
+                        return signedCents(actualHz: liveHz, rootHz: model.effectiveRootHz, target: locked)
                     } else {
                         return liveCents
                     }

--- a/Tenney/PhaseScopeTunerView.swift
+++ b/Tenney/PhaseScopeTunerView.swift
@@ -84,7 +84,7 @@ struct PhaseScopeTunerView: View {
 
     var body: some View {
         let target = store.lockedTarget ?? parseRatioText(model.display.ratioText)
-        let rootHz = model.rootHz
+        let rootHz = model.effectiveRootHz
         let conf = model.display.confidence
         let cents: Double = {
         let hz = model.display.hz


### PR DESCRIPTION
## Summary
- anchor the mini lattice focus card to a stable 1/1 center, add tuner root status, and provide clear/reset override controls
- introduce a session-only tuner root override derived from lattice node taps and apply an effective root across tuner pipeline calculations and exports
- update tuner displays and phase scope reference handling to respect the effective tuner root instead of chasing mic-detected targets

## Testing
- Not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69585282a29c8327bd1f51e6864eba52)