### PR TITLE
Implement tuner rail presets and shortcuts

### DIFF
--- a/Tenney/ContentView.swift
+++ b/Tenney/ContentView.swift
@@ -227,6 +227,9 @@ private let libraryStore = ScaleLibraryStore.shared
                     .transition(.opacity)
                     .zIndex(10)
             }
+#if targetEnvironment(macCatalyst)
+            macKeyboardShortcuts
+#endif
         }
         .environment(\.tenneyTheme, resolvedTheme)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -581,6 +584,43 @@ private let libraryStore = ScaleLibraryStore.shared
             .presentationDragIndicator(.visible)
             .presentationBackground(.ultraThinMaterial)
     }
+
+#if targetEnvironment(macCatalyst)
+    private var macKeyboardShortcuts: some View {
+        Group {
+            Button(action: toggleRailShortcut) { EmptyView() }
+                .keyboardShortcut("r", modifiers: [.command, .option])
+            Button(action: lockTargetShortcut) { EmptyView() }
+                .keyboardShortcut("l", modifiers: .command)
+            Button(action: captureShortcut) { EmptyView() }
+                .keyboardShortcut(.return, modifiers: .command)
+            Button(action: { switchAltShortcut(delta: -1) }) { EmptyView() }
+                .keyboardShortcut("[", modifiers: .command)
+            Button(action: { switchAltShortcut(delta: 1) }) { EmptyView() }
+                .keyboardShortcut("]", modifiers: .command)
+        }
+        .frame(width: 0, height: 0)
+    }
+
+    private func toggleRailShortcut() {
+        tunerRailStore.setShowRail(!tunerRailStore.showRail)
+    }
+
+    private func lockTargetShortcut() {
+        let nearest = parseRatio(app.display.ratioText)
+        tunerStore.toggleLock(currentNearest: nearest)
+    }
+
+    private func captureShortcut() {
+        tunerRailStore.captureCurrentSnapshot()
+    }
+
+    private func switchAltShortcut(delta: Int) {
+        let targetText = delta < 0 ? app.display.lowerText : app.display.higherText
+        guard !targetText.isEmpty, let ref = parseRatio(targetText) else { return }
+        tunerStore.lockedTarget = ref
+    }
+#endif
 
 }
 

--- a/Tenney/TunerRailClock.swift
+++ b/Tenney/TunerRailClock.swift
@@ -18,6 +18,12 @@ struct TunerRailSnapshot: Equatable {
     var isListening: Bool
     var targetKey: String
 
+    var hasLivePitch: Bool {
+        isListening && hz.isFinite && hz > 0 && confidence >= 0.3
+    }
+
+    var isListeningPlaceholder: Bool { !hasLivePitch }
+
     static let empty = TunerRailSnapshot(
         ratioText: "—",
         cents: 0,


### PR DESCRIPTION
## Summary
- add tuner rail preset container persistence and shareable capture/session state
- expand the Settings tuner rail section with preset picker, reorderable cards, and add-cards palette plus deep-link scrolling
- persist rail card collapse state per scene, add listening placeholders, and wire Mac keyboard shortcuts for rail, lock, capture, and alternates

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69585677b328832783a7e63426ba0861)