### PR TITLE
Improve tuner rail listening UX

### DIFF
--- a/Tenney/TunerRailClock.swift
+++ b/Tenney/TunerRailClock.swift
@@ -19,10 +19,10 @@ struct TunerRailSnapshot: Equatable {
     var targetKey: String
 
     var hasLivePitch: Bool {
-        isListening && hz.isFinite && hz > 0 && confidence >= 0.3
+        !isListening
     }
 
-    var isListeningPlaceholder: Bool { !hasLivePitch }
+    var isListeningPlaceholder: Bool { isListening }
 
     static let empty = TunerRailSnapshot(
         ratioText: "—",
@@ -31,7 +31,7 @@ struct TunerRailSnapshot: Equatable {
         confidence: 0,
         lowerText: "",
         higherText: "",
-        isListening: false,
+        isListening: true,
         targetKey: "none"
     )
 }
@@ -39,27 +39,94 @@ struct TunerRailSnapshot: Equatable {
 @MainActor
 final class TunerRailClock: ObservableObject {
     @Published var snapshot: TunerRailSnapshot = .empty
+    private var lastGoodSnapshot: TunerRailSnapshot = .empty
+    private var hasGoodSnapshot = false
 
     private var cancellable: AnyCancellable?
+    private static let listeningConfidenceThreshold = 0.6
 
     init(app: AppModel, hz: Double = 15.0) {
+        let initialTargetKey = Self.targetKey(for: app.display)
+        let initialSnapshot = TunerRailSnapshot(
+            ratioText: app.display.ratioText,
+            cents: app.display.cents,
+            hz: app.display.hz,
+            confidence: app.display.confidence,
+            lowerText: app.display.lowerText,
+            higherText: app.display.higherText,
+            isListening: Self.isListening(
+                display: app.display,
+                targetKey: initialTargetKey,
+                micPermission: app.micPermission
+            ),
+            targetKey: initialTargetKey
+        )
+
+        snapshot = initialSnapshot
+        if !initialSnapshot.isListening {
+            lastGoodSnapshot = initialSnapshot
+            hasGoodSnapshot = true
+        }
+
         let interval = max(0.05, min(0.5, 1.0 / hz))
         cancellable = Timer.publish(every: interval, on: .main, in: .common)
             .autoconnect()
             .sink { [weak self] _ in
                 guard let self else { return }
                 let display = app.display
-                let targetKey = "\(display.ratioText)|\(String(format: "%.0f", display.hz))"
-                snapshot = TunerRailSnapshot(
+                let targetKey = Self.targetKey(for: display)
+                let listening = Self.isListening(
+                    display: display,
+                    targetKey: targetKey,
+                    micPermission: app.micPermission
+                )
+
+                let nextSnapshot = TunerRailSnapshot(
                     ratioText: display.ratioText,
                     cents: display.cents,
                     hz: display.hz,
                     confidence: display.confidence,
                     lowerText: display.lowerText,
                     higherText: display.higherText,
-                    isListening: app.micPermission == .granted,
+                    isListening: listening,
                     targetKey: targetKey
                 )
+
+                if listening {
+                    let held = hasGoodSnapshot ? lastGoodSnapshot : snapshot
+                    snapshot = held.withListening(true)
+                } else {
+                    lastGoodSnapshot = nextSnapshot.withListening(false)
+                    hasGoodSnapshot = true
+                    snapshot = nextSnapshot
+                }
             }
+    }
+
+    private static func targetKey(for display: TunerDisplay) -> String {
+        guard display.hz.isFinite, display.hz > 0 else { return "" }
+        return "\(display.ratioText)|\(String(format: "%.0f", display.hz))"
+    }
+
+    private static func isListening(
+        display: TunerDisplay,
+        targetKey: String,
+        micPermission: MicPermissionState
+    ) -> Bool {
+        let ratioMissing = display.ratioText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || display.ratioText == "—"
+        let invalidHz = !display.hz.isFinite || display.hz <= 0
+        return micPermission != .granted
+        || ratioMissing
+        || invalidHz
+        || targetKey.isEmpty
+        || display.confidence < listeningConfidenceThreshold
+    }
+}
+
+private extension TunerRailSnapshot {
+    func withListening(_ isListening: Bool) -> TunerRailSnapshot {
+        var copy = self
+        copy.isListening = isListening
+        return copy
     }
 }


### PR DESCRIPTION
## Summary
- add a more aggressive listening gate in the tuner rail clock and hold the last good snapshot when input is weak
- render listening as an overlay/opacity treatment on rail cards to avoid layout jumps and keep content visible
- keep tuner rail lists and controls populated from held data while listening

## Testing
- Not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69585f9efe3c832795f2f0a4ce2b4928)