### PR TITLE
Use real lattice for mini tuner focus

### DIFF
--- a/Tenney/ContentView.swift
+++ b/Tenney/ContentView.swift
@@ -445,6 +445,7 @@ private let libraryStore = ScaleLibraryStore.shared
             TunerContextRailHost(
                 store: tunerRailStore,
                 app: app,
+                tunerStore: tunerStore,
                 showSettings: $showSettings,
                 globalPrimeLimit: app.tunerPrimeLimit,
                 globalAxisShift: latticeAxisShift,

--- a/Tenney/TunerRailClock.swift
+++ b/Tenney/TunerRailClock.swift
@@ -104,8 +104,9 @@ final class TunerRailClock: ObservableObject {
     }
 
     private static func targetKey(for display: TunerDisplay) -> String {
-        guard display.hz.isFinite, display.hz > 0 else { return "" }
-        return "\(display.ratioText)|\(String(format: "%.0f", display.hz))"
+        let ratio = display.ratioText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !ratio.isEmpty, ratio != "—" else { return "" }
+        return ratio
     }
 
     private static func isListening(


### PR DESCRIPTION
## Summary
- render Mini Lattice Focus with real lattice math (5×7 window, axis shift, overlays) and canonical labels tied to the current/locked target
- center the mini lattice on locked or live targets without Hz jitter and wire taps/hover to the tuner lock/preview closures
- update the rail host to pass tuner lock state and use a stable target key for rail snapshots

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958623de2c48327b0ffaf6142c4ca90)