### PR TITLE
Improve Mac prime overlay chips styling

### DIFF
--- a/Tenney/GlassUI.swift
+++ b/Tenney/GlassUI.swift
@@ -108,7 +108,16 @@ struct GlassChip: View {
             Color.clear
                 .glassEffect(.regular.tint(color.opacity(active ? 0.35 : 0.18)), in: Capsule())
         } else {
+#if os(macOS) || targetEnvironment(macCatalyst)
+            Color.clear
+                .background(.thinMaterial)
+                .overlay(
+                    Capsule()
+                        .fill(color.opacity(active ? 0.22 : 0.14))
+                )
+#else
             Color.clear.background(.thinMaterial)
+#endif
         }
     }
 }

--- a/Tenney/LatticeView.swift
+++ b/Tenney/LatticeView.swift
@@ -3001,6 +3001,9 @@ struct LatticeView: View {
                         overlayChips
                     }
                     .padding(8)
+#if os(macOS) || targetEnvironment(macCatalyst)
+                    .padding(.top, 8)
+#endif
                     .allowsHitTesting(true)
                 }
                 
@@ -3442,6 +3445,9 @@ struct LatticeView: View {
             }
             .padding(8)
         }
+#if os(macOS) || targetEnvironment(macCatalyst)
+        .scaleEffect(1.08)
+#endif
     }
 
     


### PR DESCRIPTION
## Summary
- add macOS and Mac Catalyst-only padding and scaling to the prime overlay chip bar to prevent clipping and enlarge the controls
- apply a tinted glass fill for GlassChip on Mac to align prime overlay chips with the iOS filled pill appearance

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695870577ba0832788091cfe80065a10)