### PR TITLE
Boost lattice zoom on Mac platforms

### DIFF
--- a/Tenney/LatticeCamera.swift
+++ b/Tenney/LatticeCamera.swift
@@ -17,6 +17,28 @@ struct LatticeCamera: Equatable, Sendable {
     static let minScale: CGFloat = 12.0
     static let maxScale: CGFloat = 240.0
 
+    /// Mac builds render slightly closer without changing stored zoom values or slider ranges.
+    private static let macZoomBoost: CGFloat = {
+#if os(macOS) || targetEnvironment(macCatalyst)
+        return 1.5
+#else
+        return 1.0
+#endif
+    }()
+
+    /// Platform-adjusted scale used for all world/screen math.
+    /// The raw `scale` remains the stored/user-facing value.
+    var appliedScale: CGFloat {
+        Self.appliedScale(for: scale)
+    }
+
+    private static func appliedScale(for raw: CGFloat) -> CGFloat {
+        let boosted = raw * macZoomBoost
+        let minS = minScale * macZoomBoost
+        let maxS = maxScale * macZoomBoost
+        return min(maxS, max(minS, boosted))
+    }
+
     mutating func reset() {
         translation = .zero
         scale = 72.0
@@ -30,8 +52,11 @@ struct LatticeCamera: Equatable, Sendable {
     /// Zoom by a factor around a screen-space anchor point (pinch center).
     mutating func zoom(by factor: CGFloat, anchor: CGPoint) {
         let clampedFactor = max(0.5, min(2.0, factor))
-        let oldScale = scale
-        let newScale = min(Self.maxScale, max(Self.minScale, oldScale * clampedFactor))
+        let oldRaw = scale
+        let newRaw = min(Self.maxScale, max(Self.minScale, oldRaw * clampedFactor))
+
+        let oldScale = appliedScale
+        let newScale = Self.appliedScale(for: newRaw)
         if newScale == oldScale { return }
 
         // Anchor-preserving zoom:
@@ -41,21 +66,22 @@ struct LatticeCamera: Equatable, Sendable {
         let worldX = (anchor.x - translation.x) / oldScale
         let worldY = (anchor.y - translation.y) / oldScale
 
-        scale = newScale
         translation.x = anchor.x - worldX * newScale
         translation.y = anchor.y - worldY * newScale
+        scale = newRaw
     }
 
     // MARK: - Transforms
 
     func worldToScreen(_ world: CGPoint) -> CGPoint {
-        CGPoint(x: world.x * scale + translation.x,
-                y: world.y * scale + translation.y)
+        let s = appliedScale
+        return CGPoint(x: world.x * s + translation.x,
+                       y: world.y * s + translation.y)
     }
 
     func screenToWorld(_ screen: CGPoint) -> CGPoint {
-        CGPoint(x: (screen.x - translation.x) / max(0.0001, scale),
-                y: (screen.y - translation.y) / max(0.0001, scale))
+        let s = appliedScale
+        return CGPoint(x: (screen.x - translation.x) / max(0.0001, s),
+                       y: (screen.y - translation.y) / max(0.0001, s))
     }
 }
-

--- a/Tenney/LatticeStore.swift
+++ b/Tenney/LatticeStore.swift
@@ -156,7 +156,7 @@ final class LatticeStore: ObservableObject {
 
     private func inkDuration(targetOn: Bool) -> Double {
         // camera.scale: smaller = zoomed out, larger = zoomed in
-        let z = Double(camera.scale)
+        let z = Double(camera.appliedScale)
 
         // Tune these once you feel it:
         let z0 = 24.0
@@ -918,4 +918,3 @@ extension LatticeStore {
         return (selectionOrder[0], selectionOrder[1])
     }
 }
-

--- a/Tenney/LatticeView.swift
+++ b/Tenney/LatticeView.swift
@@ -244,7 +244,7 @@ struct LatticeView: View {
     private func shouldDrawOverlayLabel(ep: Int) -> Bool {
         guard labelDensity > 0.01 else { return false }
 
-        let zoom = store.camera.scale
+        let zoom = store.camera.appliedScale
         let zoomT = clamp01((zoom - 52) / 80)
         guard zoomT >= 0.15 else { return false }
 
@@ -1512,7 +1512,7 @@ struct LatticeView: View {
     private func shouldDrawPlaneLabel(coord: LatticeCoord) -> Bool {
         guard labelDensity > 0.01 else { return false }
 
-        let zoom = store.camera.scale
+        let zoom = store.camera.appliedScale
         let zoomT = clamp01((zoom - 42) / 70)
         guard zoomT >= 0.15 else { return false }
 
@@ -2551,7 +2551,7 @@ struct LatticeView: View {
         guard gridMode != .off else { return }
 
 
-        let zoom = store.camera.scale
+        let zoom = store.camera.appliedScale
         guard zoom >= gridMinZoom else { return }
 
         let isDark = effectiveIsDark
@@ -2807,7 +2807,7 @@ struct LatticeView: View {
             Canvas(rendersAsynchronously: true) { ctx, _ in
                 let now = CACurrentMediaTime()
                 // Nodes on 3×5 plane (with shift applied)
-                let radius: Int = Int(max(8, min(48, store.camera.scale / 5)))
+                let radius: Int = Int(max(8, min(48, store.camera.appliedScale / 5)))
                 let anyNodes = layout.planeNodes(
                     in: viewRect,
                     camera: store.camera,
@@ -2845,7 +2845,7 @@ struct LatticeView: View {
                 // grid width baseline (0 if grid is off / below threshold)
                 let gridW: CGFloat = {
                     guard gridMode != .off else { return 0 }
-                    guard store.camera.scale >= gridMinZoom else { return 0 }
+                    guard store.camera.appliedScale >= gridMinZoom else { return 0 }
                     return LatticeGridWeight.fromStrength01(gridStrength).strokeWidth
                 }()
 
@@ -2858,7 +2858,7 @@ struct LatticeView: View {
                     pivot: store.pivot,
                     shift: store.axisShift,
                     camera: store.camera,
-                    zoom: store.camera.scale,
+                    zoom: store.camera.appliedScale,
                     gridStrokeWidth: gridW
                 )
 
@@ -2867,7 +2867,7 @@ struct LatticeView: View {
                     let pivotSnapshot = store.pivot
                     let shiftSnapshot = store.axisShift
                     let cameraSnapshot = store.camera
-                    let zoom = store.camera.scale
+                    let zoom = store.camera.appliedScale
                     let keys = store.selectionKeysToDraw()
 
                     // Focus info (plane only)
@@ -3240,7 +3240,7 @@ struct LatticeView: View {
         if shouldDrawPlaneLabel(coord: node.coord),
            let label = planeLabelText(for: node.coord) {
 
-            let zoomT = clamp01((store.camera.scale - 42) / 70)
+            let zoomT = clamp01((store.camera.appliedScale - 42) / 70)
             let a: CGFloat = 0.85 * zoomT * CGFloat(labelDensity)
             if a > 0.02 {
                 let text = Text(label)
@@ -3289,7 +3289,7 @@ struct LatticeView: View {
         let e5 = store.pivot.e5 + (store.axisShift[5] ?? 0)
         let shiftP = store.axisShift[p] ?? 0
 
-        let epSpan = max(6, min(12, Int(store.camera.scale / 8)))
+        let epSpan = max(6, min(12, Int(store.camera.appliedScale / 8)))
 
         // (recommended) skip far-offscreen points
         let pad: CGFloat = 60
@@ -3391,7 +3391,7 @@ struct LatticeView: View {
             if shouldDrawOverlayLabel(ep: ep),
                let label = overlayLabelText(num: num, den: den) {
 
-                let zoomT = clamp01((store.camera.scale - 52) / 80)
+                let zoomT = clamp01((store.camera.appliedScale - 52) / 80)
                 let a: CGFloat = 0.85 * zoomT * CGFloat(labelDensity)
                 let labelA: CGFloat = isAnimating ? (a * local) : a
 
@@ -3948,7 +3948,7 @@ struct LatticeView: View {
     }
 
     // 1) Prefer plane nodes around the pivot (screen distance)
-    let R = max(6, min(24, Int(store.camera.scale / 6)))
+    let R = max(6, min(24, Int(store.camera.appliedScale / 6)))
     var bestPlane: (d: CGFloat, pos: CGPoint, coord: LatticeCoord, p: Int, q: Int)?
 
     for de3 in (-R...R) {
@@ -3986,7 +3986,7 @@ struct LatticeView: View {
 
     let baseE3 = store.pivot.e3 + (store.axisShift[3] ?? 0)
     let baseE5 = store.pivot.e5 + (store.axisShift[5] ?? 0)
-    let epSpan = max(6, min(12, Int(store.camera.scale / 8)))
+    let epSpan = max(6, min(12, Int(store.camera.appliedScale / 8)))
 
     // Use the same prime set used for rendering so hit-testing matches what can appear.
     let overlayPrimes = store.renderPrimes.filter { $0 != 2 && $0 != 3 && $0 != 5 }


### PR DESCRIPTION
## Summary
- add a platform-adjusted lattice camera scale with a Mac-only zoom boost while keeping stored values the same
- apply the adjusted scale across lattice rendering, grids, labels, and hit-testing so Mac views stay closer without changing iOS behavior
- update zoom-dependent animations to follow the platform-adjusted scale

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958726cefc0832785d38a55ec1e84f4)