### PR TITLE
Add Mac Catalyst dismiss control to root Hz sheet

### DIFF
--- a/Tenney/Components/GlassDismissCircleButton.swift
+++ b/Tenney/Components/GlassDismissCircleButton.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct GlassDismissCircleButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                Circle()
+                    .modifier(GlassBlueCircle())
+                Image(systemName: "checkmark")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(.white)
+            }
+            .frame(width: 44, height: 44)
+            .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Tenney/ContentView.swift
+++ b/Tenney/ContentView.swift
@@ -1386,6 +1386,7 @@ private struct RootStudioSheet: View {
     @AppStorage(SettingsKeys.a4Choice)   private var a4Choice = "440"
     @AppStorage(SettingsKeys.a4CustomHz) private var a4Custom: Double = 440
     @AppStorage(SettingsKeys.staffA4Hz)  private var a4Staff: Double = 440
+    @Environment(\.dismiss) private var dismiss
 
     @Binding var tab: RootStudioTab
     let ns: Namespace.ID
@@ -1395,7 +1396,8 @@ private struct RootStudioSheet: View {
     @State private var highlight: RootStudioTab? = nil
 
     var body: some View {
-        ScrollViewReader { proxy in
+        ZStack(alignment: .topTrailing) {
+            ScrollViewReader { proxy in
                     ScrollView {
                         VStack(spacing: 14) {
                             // Sticky header: hero chip
@@ -1435,6 +1437,12 @@ private struct RootStudioSheet: View {
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.9) { withAnimation(.easeOut(duration: 0.25)) { highlight = nil } }
                     }
                 }
+#if targetEnvironment(macCatalyst)
+            GlassDismissCircleButton { dismiss() }
+                .padding(.top, 20)
+                .padding(.trailing, 20)
+#endif
+        }
         .onAppear {
             input = String(format: "%.1f", model.rootHz)
         }

--- a/Tenney/Settings.swift
+++ b/Tenney/Settings.swift
@@ -2769,20 +2769,7 @@ struct StudioConsoleView: View {
                 }
                 .overlay(alignment: .topTrailing) {
                     if activeCategory == nil {
-                        Button {
-                            dismiss()
-                        } label: {
-                            ZStack {
-                                Circle()
-                                    .modifier(GlassBlueCircle()) // ✅ reuse same blue glass modifier
-                                Image(systemName: "checkmark")
-                                    .font(.system(size: 18, weight: .bold))
-                                    .foregroundStyle(.white)
-                            }
-                            .frame(width: 44, height: 44)
-                            .contentShape(Circle())
-                        }
-                        .buttonStyle(.plain)
+                        GlassDismissCircleButton { dismiss() }
                         .padding(.top, 20)
                         .padding(.trailing, 20)
                         .transition(.opacity)


### PR DESCRIPTION
## Summary
- extract a shared glass dismiss circle button that reuses the Settings styling
- replace the Settings sheet close control with the shared component
- add the Mac Catalyst-only dismiss overlay to the Root Hz picker sheet without affecting other platforms

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69587dbb098c83279cfaeaf1b45663f4)