### PR TITLE
Fix lattice audition sound binding

### DIFF
--- a/Tenney/AppModel.swift
+++ b/Tenney/AppModel.swift
@@ -29,6 +29,9 @@ final class AppModel: ObservableObject {
         micPCMTap = nil
     }
 
+    @AppStorage(SettingsKeys.latticeSoundEnabled)
+    private var latticeSoundSetting: Bool = true
+
     @Published var builderPresented: Bool = false
     private var _recenterObserver: NSObjectProtocol?
     init() {
@@ -42,6 +45,7 @@ final class AppModel: ObservableObject {
             UserDefaults.standard.set(true, forKey: SettingsKeys.latticeRecenterPending)
         }
         AppModelLocator.shared = self
+        latticeAuditionOn = latticeSoundSetting
         let done = UserDefaults.standard.bool(forKey: SettingsKeys.setupWizardDone)
             self.showOnboardingWizard = !done
     }
@@ -89,7 +93,12 @@ final class AppModel: ObservableObject {
     /// Controls showing the onboarding wizard as a liquid-glass modal overlay.
     @Published var showOnboardingWizard: Bool = false
     // Lattice audition state (UtilityBar ↔ LatticeScreen sync)
-    @Published var latticeAuditionOn: Bool = false
+    @Published var latticeAuditionOn: Bool = true {
+        didSet {
+            latticeSoundSetting = latticeAuditionOn
+            postSetting(SettingsKeys.latticeSoundEnabled, latticeAuditionOn)
+        }
+    }
     // Library detent presentation
     @Published var showScaleLibraryDetent: Bool = false
     

--- a/Tenney/LatticeStore.swift
+++ b/Tenney/LatticeStore.swift
@@ -769,10 +769,6 @@ final class LatticeStore: ObservableObject {
                 .removeDuplicates()
                 .sink { [weak self] on in
                     guard let self else { return }
-                    if let app = AppModelLocator.shared, app.latticeAuditionOn != on {
-                        app.latticeAuditionOn = on
-                    }
-
                     if self.auditionEnabled != on { self.auditionEnabled = on }
                 }
                 .store(in: &cancellables)
@@ -783,6 +779,9 @@ final class LatticeStore: ObservableObject {
             .dropFirst()
             .sink { [weak self] on in
                 guard let self = self else { return }
+                if let app = AppModelLocator.shared, app.latticeAuditionOn != on {
+                    app.latticeAuditionOn = on
+                }
                 AppModelLocator.shared?.playTestTone = false
                 if on {
                     guard self.latticeSoundEnabled else { return }

--- a/Tenney/Settings.swift
+++ b/Tenney/Settings.swift
@@ -339,9 +339,6 @@ struct StudioConsoleView: View {
     @AppStorage(SettingsKeys.tunerNeedleHoldMode)
     private var tunerNeedleHoldRaw: String = NeedleHoldMode.snapHold.rawValue
 
-    @AppStorage(SettingsKeys.latticeSoundEnabled)
-    private var latticeSoundEnabled: Bool = true
-
     @State private var settingsHeaderBaselineMinY: CGFloat? = nil
     @AppStorage(SettingsKeys.latticeConnectionMode)
     private var latticeConnectionModeRaw: String = LatticeConnectionMode.chain.rawValue
@@ -388,6 +385,12 @@ struct StudioConsoleView: View {
     @Environment(\.horizontalSizeClass) private var hSizeClass
     @Environment(\.colorScheme) private var systemScheme
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    private var latticeSoundBinding: Binding<Bool> {
+        Binding(
+            get: { app.latticeAuditionOn },
+            set: { app.latticeAuditionOn = $0 }
+        )
+    }
 
 //  THeme
     private var effectiveIsDark: Bool {
@@ -4076,7 +4079,7 @@ private struct GlassNavTile<Destination: View>: View {
         ) {
             LatticeUIControlsPager(
                 latticeConnectionModeRaw: $latticeConnectionModeRaw,
-                soundOn: $latticeSoundEnabled,
+                soundOn: latticeSoundBinding,
                 nodeSizeRaw: $nodeSize,
                 labelDensity: $labelDensity,
                 guidesOn: $guidesOn,

--- a/Tenney/TenneyApp.swift
+++ b/Tenney/TenneyApp.swift
@@ -38,8 +38,8 @@ struct TenneyApp: App {
         }
     }
 
-    @StateObject private var latticeStore = LatticeStore()
     @StateObject private var appModel = AppModel()
+    @StateObject private var latticeStore = LatticeStore()
 
     init() {
         seedLatticeSoundDefaultIfNeeded()


### PR DESCRIPTION
## Summary
- source the lattice audition flag from the stored sound setting in AppModel
- sync lattice store and settings UI to that shared binding to keep Utility Bar and toolbar in lockstep
- ensure the store initializes after AppModel so the shared state is wired immediately

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69587fda771483278efd10bbc8ffd7c3)