### PR TITLE
Fix tuner ratio display to include octave offsets

### DIFF
--- a/Tenney/AppModel.swift
+++ b/Tenney/AppModel.swift
@@ -450,12 +450,12 @@ final class AppModel: ObservableObject {
             // Your JI mapping & display (preserve RatioSolver & neighbors)
             let pack = ratioSolver.nearestWithNeighbors(for: fSmoothed, rootHz: effectiveRootHz, primeLimit: tunerPrimeLimit)
             let view = TunerDisplay(
-                ratioText: pack.main.ratioString,
+                ratioText: tunerDisplayRatioString(pack.main),
                 cents: signedCents(actualHz: fSmoothed, rootHz: effectiveRootHz, target: pack.main),
                 hz: fSmoothed,
                 confidence: res.confidence,
-                lowerText: pack.lower.ratioString,
-                higherText: pack.higher.ratioString
+                lowerText: tunerDisplayRatioString(pack.lower),
+                higherText: tunerDisplayRatioString(pack.higher)
             )
             
             Task { @MainActor in

--- a/Tenney/Ratio+Octave.swift
+++ b/Tenney/Ratio+Octave.swift
@@ -53,6 +53,28 @@ private func canonicalPQAroundUnison(_ p: Int, _ q: Int, octave: Int) -> (Int, I
     return (num / g, den / g)
 }
 
+/// Returns a reduced fraction that applies octave offset directly (no unit-octave folding).
+func unfoldedRatioString(_ r: RatioRef) -> String {
+    guard r.p > 0 && r.q > 0 else { return "\(r.p)/\(r.q)" }
+
+    var num = r.p
+    var den = r.q
+
+    if r.octave > 0 {
+        for _ in 0..<r.octave { num &*= 2 }
+    } else if r.octave < 0 {
+        for _ in 0..<(-r.octave) { den &*= 2 }
+    }
+
+    let g = gcd(num, den)
+    return "\(num / g)/\(den / g)"
+}
+
+/// Tuner-only helper: formats RatioResult without folding into the unit octave.
+func tunerDisplayRatioString(_ r: RatioResult) -> String {
+    unfoldedRatioString(RatioRef(p: r.num, q: r.den, octave: r.octave))
+}
+
 
 /// Frequency from RatioRef with canonicalized p/q (1 ≤ p/q < 2), no fold unless asked.
 func frequencyHz(rootHz: Double, ratio: RatioRef, foldToAudible: Bool = false,

--- a/Tenney/TunerViewModel.swift
+++ b/Tenney/TunerViewModel.swift
@@ -124,10 +124,10 @@ final class TunerViewModel: ObservableObject {
         // “too far” threshold (post-selection)
         isFarValue = abs(best.cents) > 120
 
-        displayRatio = "\(best.target.num)/\(best.target.den)"
+        displayRatio = tunerDisplayRatioString(best.target)
         centsText = String(format: "%+0.1f cents", best.cents)
         hzText = String(format: "%0.2f Hz", hz)
-        altRatios = alts.map { "\($0.num)/\($0.den)" }
+        altRatios = alts.map { tunerDisplayRatioString($0) }
     }
 
 }

--- a/TenneyTests/TunerRatioDisplayTests.swift
+++ b/TenneyTests/TunerRatioDisplayTests.swift
@@ -1,0 +1,25 @@
+//
+//  TunerRatioDisplayTests.swift
+//  TenneyTests
+//
+//  Created by OpenAI on 2024-05-07.
+//
+
+import Testing
+@testable import Tenney
+
+struct TunerRatioDisplayTests {
+
+    @Test func unfoldedRatioRefFormatting() async throws {
+        let downTwo = RatioRef(p: 1, q: 1, octave: -2, monzo: [:])
+        #expect(unfoldedRatioString(downTwo) == "1/4")
+
+        let upOne = RatioRef(p: 5, q: 4, octave: 1, monzo: [:])
+        #expect(unfoldedRatioString(upOne) == "5/2")
+    }
+
+    @Test func tunerDisplayUsesUnfoldedRatioResult() async throws {
+        let result = RatioResult(num: 3, den: 2, octave: -1)
+        #expect(tunerDisplayRatioString(result) == "3/4")
+    }
+}


### PR DESCRIPTION
## Summary
- add a tuner-only formatter that unfolds octave offsets into the displayed ratio fraction
- switch tuner readouts and alternates to the unfolded formatter while leaving lattice logic unchanged
- cover unfolded ratio formatting and the tuner display helper with unit tests

## Testing
- swift test (fails: Could not find Package.swift in this directory or any of its parent directories.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958b80143288327a773481f7580d5e8)