### PR TITLE
Inject shared tuner store for lock overlay

### DIFF
--- a/Tenney/ContentView.swift
+++ b/Tenney/ContentView.swift
@@ -47,7 +47,7 @@ private let libraryStore = ScaleLibraryStore.shared
     @Environment(\.tenneyPracticeActive) private var practiceActive
     @Environment(\.verticalSizeClass) private var vSize
 
-    @StateObject private var tunerStore = TunerStore()
+    @EnvironmentObject private var tunerStore: TunerStore
     @State private var latticeAxisShift: [Int:Int] = loadLatticeAxisShiftSnapshot()
     @EnvironmentObject private var app: AppModel
     @State private var mode: AppScreenMode = .tuner

--- a/Tenney/LearnTenneyPractice.swift
+++ b/Tenney/LearnTenneyPractice.swift
@@ -109,11 +109,13 @@ private struct PracticeContent: View {
 
 private struct LatticePracticeHost: View {
     let stepIndex: Int
+    @StateObject private var tunerStore = TunerStore()
 
     var body: some View {
         ZStack {
             // ✅ Always keep the real sandbox mounted (this is where your UtilityBar comes from)
             ContentView()
+                .environmentObject(tunerStore)
                 .environment(\.tenneyPracticeActive, true)
                 .ignoresSafeArea()
                 .toolbar(.hidden, for: .navigationBar)

--- a/Tenney/TenneyApp.swift
+++ b/Tenney/TenneyApp.swift
@@ -39,6 +39,7 @@ struct TenneyApp: App {
     }
 
     @StateObject private var appModel = AppModel()
+    @StateObject private var tunerStore = TunerStore()
     @StateObject private var latticeStore = LatticeStore()
 
     init() {
@@ -71,6 +72,7 @@ struct TenneyApp: App {
             ContentView()
                 .environmentObject(latticeStore)
                 .environmentObject(appModel)
+                .environmentObject(tunerStore)
                 .preferredColorScheme(appScheme)   // ← global scheme driven by Settings
                 .onAppear { appModel.configureAndStart() }
 


### PR DESCRIPTION
## Summary
- Provide a shared `TunerStore` instance from the app entry point so ContentView observes the same lock state as the tuner UI
- Inject a store when embedding ContentView in practice flows to keep lock state updates visible there as well

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695994fbc2748327aa13cd1bb8fdbc58)