### PR TITLE
Pass heldByConfidence into ChronoDial

### DIFF
--- a/Tenney/ContentView.swift
+++ b/Tenney/ContentView.swift
@@ -752,6 +752,7 @@ extension Notification.Name {
 
          case .chronoDial:
              ChronoDial(
+                 heldByConfidence: held,
                  cents: centsShown,
                  confidence: liveConf,
                  inTuneWindow: 5,


### PR DESCRIPTION
## Summary
- pass the held-by-confidence flag through the ChronoDial tuner style to match Gauge behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959b4c7093c8327aefb849dd7710c3f)