### PR TITLE
Add opt-in Sentry crash reporting and diagnostics upload

### DIFF
--- a/Tenney/TenneyApp.swift
+++ b/Tenney/TenneyApp.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import Sentry
 
 import AVFAudio
 #if canImport(UIKit)
@@ -69,9 +68,7 @@ struct TenneyApp: App {
         } else {
             UserDefaults.standard.set(0, forKey: SettingsKeys.lastSessionCrashTimestamp)
         }
-        if UserDefaults.standard.bool(forKey: SettingsKeys.crashReportingEnabled) {
-            SentryService.shared.setEnabled(true)
-        }
+        if crashReportingEnabled { SentryService.shared.setEnabled(true) }
 #if canImport(UIKit)
         NotificationCenter.default.addObserver(
             forName: UIApplication.willTerminateNotification,


### PR DESCRIPTION
## Summary
- start Sentry only when crash reporting is explicitly enabled and configure production-safe options
- add Sentry debug bundle upload helper that attaches exported diagnostics and clipboard summary
- wire diagnostics sharing buttons to send bundles to Sentry when crash reporting is on while preserving existing UI behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959ea78e67883279ca43b0ace0d46cb)