### PR TITLE
Ensure lattice previews stay silent and non-persistent

### DIFF
--- a/Tenney/ContentView.swift
+++ b/Tenney/ContentView.swift
@@ -50,6 +50,7 @@ private let libraryStore = ScaleLibraryStore.shared
     @StateObject private var tunerStore = TunerStore()
     @State private var latticeAxisShift: [Int:Int] = loadLatticeAxisShiftSnapshot()
     @EnvironmentObject private var app: AppModel
+    @EnvironmentObject private var latticeStore: LatticeStore
     @State private var mode: AppScreenMode = .tuner
     @State private var showSettings = false
     
@@ -256,8 +257,14 @@ private let libraryStore = ScaleLibraryStore.shared
         // Still in ContentView.body view modifiers
         .onAppear {
             presentWhatsNewIfEligible()
+            if app.showOnboardingWizard {
+                latticeStore.hardResetAudioAndTransientState(clearSelection: !setupWizardDone)
+            }
         }
         .onChange(of: app.showOnboardingWizard) { isShowing in
+            if isShowing {
+                latticeStore.hardResetAudioAndTransientState(clearSelection: !setupWizardDone)
+            }
             // As soon as onboarding closes, show What's New (if needed)
             if !isShowing { presentWhatsNewIfEligible() }
         }

--- a/Tenney/TenneyApp.swift
+++ b/Tenney/TenneyApp.swift
@@ -56,6 +56,10 @@ struct TenneyApp: App {
     init() {
         seedLatticeSoundDefaultIfNeeded()
         configureAudioSessionFromDefaults()
+        let isFirstRun = (UserDefaults.standard.object(forKey: SettingsKeys.setupWizardDone) == nil)
+            || !UserDefaults.standard.bool(forKey: SettingsKeys.setupWizardDone)
+        ToneOutputEngine.shared.stopAll()
+        latticeStore.hardResetAudioAndTransientState(clearSelection: isFirstRun) // silence without flipping settings.
         let crashInfo = SessionCrashMarker.shared.onLaunch()
         if let crashInfo {
             DiagnosticsCenter.shared.log(

--- a/Tenney/WhatsNewSheet.swift
+++ b/Tenney/WhatsNewSheet.swift
@@ -101,7 +101,7 @@ struct WhatsNewSheet: View {
     
     private struct RealLatticePreview: View {
         let app: AppModel
-        @StateObject private var store = LatticeStore()
+        @StateObject private var store = LatticeStore(allowPersistence: false)
 
         let gridMode: LatticeGridMode?
         let connectionMode: LatticeConnectionMode?
@@ -128,12 +128,16 @@ struct WhatsNewSheet: View {
                 .environment(\.latticePreviewHideDistance, true)
                 .allowsHitTesting(false)
                 .onAppear {
+                    store.auditionEnabled = false // preview-only silence without touching defaults.
+                    store.hardResetAudioAndTransientState(clearSelection: true)
                     // deterministic “real nodes” for node-restyle previews
                     if !seedSelection.isEmpty {
-                        store.clearSelection()
                         store.setPivot(.init(e3: 0, e5: 0))
                         for c in seedSelection { store.toggleSelection(c) }
                     }
+                }
+                .onDisappear {
+                    store.hardResetAudioAndTransientState(clearSelection: false)
                 }
         }
     }


### PR DESCRIPTION
### Motivation
- Fix a launch-time audio + lattice-state bug where preview code seeded selections on the real store and caused unexpected audition and persisted selections.  
- Prevent any preview view from writing to the app `lattice.persist.v1` key or emitting audition audio.  
- Guarantee the app never starts emitting tones on cold launch while not mutating persisted user defaults for audition/sound toggles.  
- Make minimal, surgical changes that avoid broad behavioral changes outside transient/preview state.

### Description
- Added a non-persistent mode to `LatticeStore` via `init(allowPersistence: Bool = true)` and gated `load()`, `save()` and `scheduleSave()` behind `allowPersistence` so preview stores cannot write/read `lattice.persist.v1`.  
- Added `func hardResetAudioAndTransientState(clearSelection: Bool)` to `LatticeStore` to cancel pending auditions, stop audio via `ToneOutputEngine.shared.stopAll()`, clear transient voice maps, and optionally clear in-memory selection state without touching `UserDefaults`.  
- Updated `WhatsNewSheet.RealLatticePreview` to use `@StateObject private var store = LatticeStore(allowPersistence: false)`, set `store.auditionEnabled = false`, call `hardResetAudioAndTransientState(clearSelection: true)` before seeding, seed selection into the preview-only store, and call a cleanup `hardResetAudioAndTransientState(clearSelection: false)` on `onDisappear` so previews are silent and non-persistent.  
- Defensive guards: only wire `LatticeStore` ↔ `AppModelLocator` synchronization (and `playTestTone` side effects) when `allowPersistence` is true, and call the new `hardResetAudioAndTransientState` from app lifecycle points (`TenneyApp.init()` and ContentView onboarding hooks) to ensure silence on cold launch/onboarding without mutating persisted settings.

### Testing
- No automated tests were executed against these changes.  
- Basic compile-time validation was performed by applying the changes in the project (no runtime test suite run).  
- Manual QA plan (follow-up): validate fresh install + onboarding shows no audio, normal launches produce no auto-audition, and the What’s New preview remains silent and does not alter persisted lattice selection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965ff1983a88327a4d9e8c4083e27bf)