### PR TITLE
Clear lattice selections on first activation

### DIFF
--- a/Tenney/TenneyApp.swift
+++ b/Tenney/TenneyApp.swift
@@ -95,9 +95,17 @@ struct TenneyApp: App {
                 .environmentObject(latticeStore)
                 .environmentObject(appModel)
                 .preferredColorScheme(appScheme)
-                .onAppear { appModel.configureAndStart() }
+                .onAppear {
+                    appModel.configureAndStart()
+                    if scenePhase == .active {
+                        latticeStore.performBootSelectionClearIfNeeded()
+                    }
+                }
                 .onChange(of: crashReportingEnabled) { SentryService.shared.setEnabled($0) }
                 .onChange(of: scenePhase) { phase in
+                    if phase == .active {
+                        latticeStore.performBootSelectionClearIfNeeded()
+                    }
                     if phase == .background || phase == .inactive {
                         SessionCrashMarker.shared.markCleanTermination()
                     }
@@ -126,9 +134,17 @@ struct TenneyApp: App {
                 .environmentObject(latticeStore)
                 .environmentObject(appModel)
                 .preferredColorScheme(appScheme)   // ← global scheme driven by Settings
-                .onAppear { appModel.configureAndStart() }
+                .onAppear {
+                    appModel.configureAndStart()
+                    if scenePhase == .active {
+                        latticeStore.performBootSelectionClearIfNeeded()
+                    }
+                }
                 .onChange(of: crashReportingEnabled) { SentryService.shared.setEnabled($0) }
                 .onChange(of: scenePhase) { phase in
+                    if phase == .active {
+                        latticeStore.performBootSelectionClearIfNeeded()
+                    }
                     if phase == .background || phase == .inactive {
                         SessionCrashMarker.shared.markCleanTermination()
                     }


### PR DESCRIPTION
### Motivation
- Prevent stale persisted or transient selections from causing nodes to appear selected and tones to play on cold app launch. 
- Ensure the first time the app becomes active after process start the lattice always has zero selected nodes and no auditioning voices. 
- Preserve existing background/foreground behavior and avoid changing persisted user toggles or settings. 
- Make the fix minimal and audio-safe to avoid regressions in the tone engine.

### Description
- Add a boot-only gate `didPerformBootSelectionClear` and public `performBootSelectionClearIfNeeded()` to `LatticeStore.swift` which runs exactly once per process and performs the boot clear routine. 
- Implement audio-safe boot clearing by cancelling pending audition work, calling `stopSelectionAudio(hard: true)` and `ToneOutputEngine.shared.stopAll()`, and repeating stops as a belt-and-suspenders step. 
- Add `clearAllSelectionsSilently()` to directly mutate selection containers and transient state (e.g. `selected`, `selectionOrder`, ghost sets, `selectionOrderKeys`, `selectionAnims`, `pausedPlane`, trigger timestamps) without firing toggles, audition paths, or persistence. 
- Suppress scheduled persistence during the boot clear by gating `scheduleSave()` with `suppressPersist`, and guard `load()` so restored selections are not re-applied when `didPerformBootSelectionClear` is set. 
- Hook the boot clear from the app lifecycle in `TenneyApp.swift` by calling `latticeStore.performBootSelectionClearIfNeeded()` from `onAppear` and in the `scenePhase` `.active` transitions so it runs on initial activation but not when returning from background.

### Testing
- Automated tests: none were executed on the modified code. 
- Manual test checklist (recommended): cold-launch to confirm zero selected nodes and silence, select nodes to confirm normal auditioning, background/foreground to confirm selections are preserved, and force-quit then relaunch to re-confirm cold-boot silence.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966a042bd8c8327ae4c53c533a43045)