### PR TITLE
Fix lattice voice ownership and boot audio cleanup

### DIFF
--- a/Tenney/LatticeView.swift
+++ b/Tenney/LatticeView.swift
@@ -1854,7 +1854,14 @@ struct LatticeView: View {
         // Stop any previous preview instantly, then start the new one
         if let id = infoVoiceID { ToneOutputEngine.shared.release(id: id, seconds: 0.0) }
         guard (UserDefaults.standard.object(forKey: SettingsKeys.latticeSoundEnabled) as? Bool ?? true) else { return }
-        infoVoiceID = ToneOutputEngine.shared.sustain(freq: hz, amp: 0.22)
+        infoVoiceID = ToneOutputEngine.shared.sustain(
+            freq: hz,
+            amp: 0.22,
+            owner: .other,
+            ownerKey: "lattice:info",
+            attackMs: nil,
+            releaseMs: nil
+        )
         infoOctaveOffset = newOffset
     }
 

--- a/Tenney/ScaleBuilderScreen.swift
+++ b/Tenney/ScaleBuilderScreen.swift
@@ -992,7 +992,14 @@ struct ScaleBuilderScreen: View {
                 ToneOutputEngine.shared.retune(id: id, to: f, hardSync: false)
             } else {
                 guard soundOn else { return }
-                    let id = ToneOutputEngine.shared.sustain(freq: f, amp: Float(safeAmp), owner: .builder, attackMs: 4, releaseMs: 40)
+                    let id = ToneOutputEngine.shared.sustain(
+                        freq: f,
+                        amp: Float(safeAmp),
+                        owner: .builder,
+                        ownerKey: "builder:pad:\(idx)",
+                        attackMs: 4,
+                        releaseMs: 40
+                    )
                 voiceForIndex[idx] = id
             }
         }
@@ -1102,7 +1109,14 @@ struct ScaleBuilderScreen: View {
                 let off = padOctaveOffset[idx, default: 0]
                 let f = foldToAudible(root * (Double(cn) / Double(cd)) * pow(2.0, Double(ratio.octave + off)))
                 guard soundOn else { return }
-                let voiceID = ToneOutputEngine.shared.sustain(freq: f, amp: Float(safeAmp), owner: .builder, attackMs: 4, releaseMs: 40)
+                let voiceID = ToneOutputEngine.shared.sustain(
+                    freq: f,
+                    amp: Float(safeAmp),
+                    owner: .builder,
+                    ownerKey: "builder:pad:\(idx)",
+                    attackMs: 4,
+                    releaseMs: 40
+                )
                 voiceForIndex[idx] = voiceID
             }
         }
@@ -1127,7 +1141,14 @@ struct ScaleBuilderScreen: View {
                     guard soundOn else { return }
 
                     guard soundOn else { return }
-                    let voiceID = ToneOutputEngine.shared.sustain(freq: f, amp: Float(safeAmp), owner: .builder, attackMs: 4, releaseMs: 40)
+                    let voiceID = ToneOutputEngine.shared.sustain(
+                        freq: f,
+                        amp: Float(safeAmp),
+                        owner: .builder,
+                        ownerKey: "builder:preview:\(i)",
+                        attackMs: 4,
+                        releaseMs: 40
+                    )
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.22) {
                         ToneOutputEngine.shared.release(id: voiceID, seconds: 0.06)
                     }

--- a/Tenney/ScaleLibrarySheet.swift
+++ b/Tenney/ScaleLibrarySheet.swift
@@ -235,7 +235,14 @@ private extension ScaleLibrarySheet {
                 let (cn, cd) = canonicalPQUnit(r.p, r.q)
                 let f = foldToAudible(root * (Double(cn) / Double(cd)))
                 guard (UserDefaults.standard.object(forKey: "Tenney.SoundOn") as? Bool ?? true) else { return }
-                let id = ToneOutputEngine.shared.sustain(freq: f, amp: 0.16)
+                let id = ToneOutputEngine.shared.sustain(
+                    freq: f,
+                    amp: 0.16,
+                    owner: .other,
+                    ownerKey: "scaleLibrary:preview",
+                    attackMs: nil,
+                    releaseMs: nil
+                )
 
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.22) {
                                     ToneOutputEngine.shared.release(id: id, seconds: 0.0)


### PR DESCRIPTION
### Motivation
- Cold launches could create an orphan 1/1 voice and then stack a second voice when the user tapped, indicating multiple voice ownership paths and selection restore race conditions.
- The goal is to start with zero selections on fresh process start, avoid orphan/duplicate voices, and ensure toggling a node stops all audio for that node without flipping persisted audition settings.

### Description
- Added per-owner-key tracking in `ToneOutputEngine` (`ownerKey`, `activeVoicesByOwner`) and made `sustain(...)` replace any existing voice for the same owner key so voices never stack for a logical owner.
- Added debug-only logging behind `#if DEBUG` that prints START/STOP events with owner key, frequency, timestamp and callsite to help locate boot-originated voices.
- Exposed `stop(ownerKey:releaseSeconds:...)` and wired `stopAll()` to clear owner bookkeeping so audio can be stopped authoritatively by owner key.
- Unified lattice owner keys via `latticeOwnerKey(...)` in `LatticeStore` and switched every lattice/ghost selection path to pass a canonical ownerKey when calling `ToneOutputEngine.sustain(...)` and `stop(...)` so selection-driven audio is a single source of truth.
- Implemented a boot-only selection-clear guard (`didBootSelectionClearThisProcess`) and `performBootSelectionClearIfNeeded()` which cancels pending auditions, calls `stopAll()`, clears selection state silently (without toggles/persist flips), and prevents re-applying selection based on the cold-boot logic.
- Updated incidental callsites (builder pads/previews, lattice info tone, scale library preview) to provide explicit owner keys so they participate correctly in the one-owner==one-voice model.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966a4e7c55c832783865eb953cd37d3)