### PR TITLE
Restore envelope ramps, sync lattice audition to selection, and persist per-node octave offsets

### DIFF
--- a/Tenney/LatticeView.swift
+++ b/Tenney/LatticeView.swift
@@ -1689,7 +1689,6 @@ struct LatticeView: View {
                 let raw = app.rootHz * (Double(cn) / Double(cd))
                 let freq = foldToAudible(raw, minHz: 20, maxHz: 5000)
                 releaseInfoVoice()
-                infoOctaveOffset = 0
 
                 focusedPoint = (
                     pos: cand.pos,
@@ -1716,9 +1715,11 @@ struct LatticeView: View {
                 #endif
                     }
                     store.toggleSelection(c)
+                    infoOctaveOffset = store.octaveOffset(for: c)
                     selectionHapticTick &+= 1
                 } else if let g = cand.ghost {
                     store.toggleOverlay(prime: g.prime, e3: g.e3, e5: g.e5, eP: g.eP)
+                    infoOctaveOffset = 0
                     selectionHapticTick &+= 1
                 }
 
@@ -3603,12 +3604,18 @@ struct LatticeView: View {
                             let newOffset = infoOctaveOffset - 1
                             let hzNew = f.hz * pow(2.0, Double(newOffset))
                             switchInfoTone(toHz: hzNew, newOffset: newOffset)
+                            if let coord = f.coord, store.selected.contains(coord) {
+                                store.setOctaveOffset(for: coord, to: newOffset)
+                            }
                         }
 
                         GlassPuckButton(systemName: "chevron.up", isEnabled: canUp) {
                             let newOffset = infoOctaveOffset + 1
                             let hzNew = f.hz * pow(2.0, Double(newOffset))
                             switchInfoTone(toHz: hzNew, newOffset: newOffset)
+                            if let coord = f.coord, store.selected.contains(coord) {
+                                store.setOctaveOffset(for: coord, to: newOffset)
+                            }
                         }
                     }
                     if store.labelMode == .heji {


### PR DESCRIPTION
### Motivation

- Recent voice-owner changes removed an envelope/ramp path and introduced a fallback 1/1 audition and octave snap-back, so selection audition and per-node transposition must be restored without changing persisted defaults.
- Audition toggles must start/stop only the exact selected nodes and must use configured attack/release ramps (no hard stops) to avoid audible glitches.
- Octave transposition must be stored per node so selecting additional nodes does not reset a node’s octave offset.

### Description

- ToneOutputEngine: `sustain(...)` now updates/retunes existing owner voices instead of hard-stopping and reallocating them, and uses the provided `attackMs`/`releaseMs` (falling back to `config`) when scheduling; added DEBUG logging for `START`/`UPDATE`/`STOP` with envelope parameters for diagnostics.
- LatticeStore: added per-node octave storage (`octaveOffsetByCoord` and `octaveOffsetByGhost`), helpers `setOctaveOffset(...)`/`octaveOffset(for:)`, and applied octave offsets inside `exactFreq(...)` and `selectionRefs(...)` so audition and builder payloads reflect node transposition.
- LatticeStore: implemented `syncAuditionVoicesToSelection(reason:)` as the single source-of-truth that starts/updates sustained voices for the current selected nodes (using `latticeOwnerKey(...)`), stops any voices not in the selection (with release ramp), and never auto-falls back to 1/1 unless actually selected.
- LatticeStore: wired `syncAuditionVoicesToSelection` into selection toggles, audition toggle, and octave changes; replaced ad-hoc per-toggle starts with the sync function, and ensured `stopSelectionAudio`/`stopAllLatticeVoices` use release ramps (not hard stops) unless explicit hard paths are requested.
- LatticeView: keep `infoOctaveOffset` in sync with the store and persist octave stepper actions to the store by calling `setOctaveOffset(for:to:)` so octave changes survive selection refreshes.
- Selection audio: added a `pausedPlane` mechanism so previewing/info-tone logic can pause/resume only the focused node without losing others, and `syncAuditionVoicesToSelection` respects paused nodes.
- All debug instrumentation is guarded by `#if DEBUG` so production behavior is unaffected.

### Testing

- Automated tests: none executed in this rollout (no unit/UI test run was requested or performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966ab8b5f2483278f94c1a5e6d0871a)