### PR TITLE
Make audition toggle authoritative and normalize lattice selection state

### DIFF
--- a/Tenney/LatticeScreen.swift
+++ b/Tenney/LatticeScreen.swift
@@ -46,6 +46,11 @@ struct LatticeScreen: View {
                 // If your app sets AppModelLocator.shared in TenneyApp/ContentView already, this is harmless.
                 // Keep the root provider updated (future-proof if you migrate LatticeStore to use it).
                 LatticeStore.rootHzProvider = { AppModelLocator.shared?.rootHz ?? 415.0 }
+                store.normalizeSelectionState(reason: "lattice appear")
+                store.resyncAuditionToSelection(forceRebuild: false, reason: "lattice appear")
+#if DEBUG
+                store.debugLogSelectionState(reason: "lattice appear")
+#endif
             }
             .onChange(of: scenePhase) { phase in
                 if phase != .active {
@@ -73,6 +78,9 @@ struct LatticeScreen: View {
             .onDisappear {
                 store.stopSelectionAudio(hard: true)
                store.stopAllLatticeVoices(hard: true)
+#if DEBUG
+                store.debugLogSelectionState(reason: "lattice disappear")
+#endif
             }
 #if !os(macOS)
             .navigationTitle("Lattice")


### PR DESCRIPTION
### Motivation
- Fix two regressions where toggling audition ON did not reliably (re-)attack voices for all selected nodes and navigating away/back produced “ring-only” ghost selections not present in the tray/path/audio.
- Ensure a single authoritative source of truth for selection order/set so UI rings, tray, path, and audition remain in sync.

### Description
- Add `resyncAuditionToSelection(forceRebuild:reason:)` in `LatticeStore.swift` to authoritativey rebuild/stop/sustain lattice voices from the current selection and support a forced rebuild path to guarantee re-attack of tones.
- Keep `syncAuditionVoicesToSelection(reason:)` as a thin wrapper that calls the new `resyncAuditionToSelection` with `forceRebuild: false` and call the forced resync on audition toggle to guarantee audible re-attack.
- Add `normalizeSelectionState(reason:)` to reconcile `selected` / `selectionOrder` / `selectionOrderGhosts` and sanitize `selectionOrderKeys` so order and set never diverge, and call it from the lattice lifecycle.
- Wire lifecycle hooks in `LatticeScreen.swift` to call `normalizeSelectionState` and `resyncAuditionToSelection` on `.onAppear` and add debug logging for appear/disappear and selection changes, while avoiding global `stopAll` except for hard/emergency paths.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966b3149eb08327aea818d0dc3680cf)