### PR TITLE
Ensure lattice audition reliably resumes when toggled back on

### DIFF
--- a/Tenney/LatticeView.swift
+++ b/Tenney/LatticeView.swift
@@ -274,7 +274,6 @@ struct LatticeView: View {
     @State private var pausedForInfoCoord: LatticeCoord? = nil
     
     // LatticeView.swift
-    @State private var reenableAuditionWorkItem: DispatchWorkItem?
     
     @State private var selectionHapticTick: Int = 0
     @State private var focusHapticTick: Int = 0
@@ -1585,11 +1584,7 @@ struct LatticeView: View {
     private func silenceSelectionMomentarily(_ duration: TimeInterval = 0.06) {
         guard store.auditionEnabled else { return }
         // Briefly pause selection audition so only the info voice is heard
-        store.auditionEnabled = false
-        reenableAuditionWorkItem?.cancel()
-        let work = DispatchWorkItem { store.auditionEnabled = true }
-        reenableAuditionWorkItem = work
-        DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: work)
+        store.pauseAuditionForInfoVoice(durationMS: Int(duration * 1000.0))
     }
     
     


### PR DESCRIPTION
### Motivation
- Fix a regression where selected lattice nodes do not resume sounding after toggling audition OFF then ON without requiring a selection change. 
- Make the audition-ON path authoritative so prior per-voice bookkeeping cannot block restart, and remove the fragile view-level OFF→ON hack used for the info voice.

### Description
- In `LatticeStore.resyncAuditionToSelection(forceRebuild:reason:)` call a new `resetAuditionStateForReenable()` when `forceRebuild` is requested so auditon re-enable performs a lattice-only hard reset before restarting voices. 
- Implemented `resetAuditionStateForReenable()` to `cancelPendingAuditions()` and `stopSelectionAudio(hard: true)` to ensure pending/cached state cannot block re-attack. 
- Added `pauseAuditionForInfoVoice(durationMS:)` to `LatticeStore` which pauses selection audition and schedules a reliable resume that sets `auditionEnabled = true` and calls `resyncAuditionToSelection(forceRebuild: true, reason: "info voice resume")`.
- Replaced the LatticeView hack that toggled `auditionEnabled` directly with a call to `store.pauseAuditionForInfoVoice(...)` so the info voice pause/resume uses the authoritative resume path. 
- Added debug-only logging prints to the `$auditionEnabled` sink, start/end of `resyncAuditionToSelection`, and `stopSelectionAudio(hard:)` to make the OFF→ON lifecycle and voice counts observable in debug builds. 
- Small bookkeeping additions: added `reenableAuditionWorkItem` to `LatticeStore` and cancelled pending auditions where appropriate.

### Testing
- No automated tests were executed as part of this change; no CI/unit run was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966baed6cb083278c6bc97643e41c5d)