### PR TITLE
Add global ScreenShell to paint safe areas and standardize chrome

### DIFF
--- a/Tenney/ContentView.swift
+++ b/Tenney/ContentView.swift
@@ -250,8 +250,11 @@ private let libraryStore = ScaleLibraryStore.shared
         }
         .environment(\.tenneyTheme, resolvedTheme)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-
-        .background(resolvedTheme.surfaceTint.ignoresSafeArea())
+        .screenShell {
+            resolvedTheme.surfaceTint
+        }
+        .toolbarBackground(.visible, for: .navigationBar)
+        .toolbarBackground(.visible, for: .tabBar)
 
         // Still in ContentView.body view modifiers
         .onAppear {
@@ -287,7 +290,7 @@ private let libraryStore = ScaleLibraryStore.shared
                 withAnimation(.easeOut(duration: 0.25)) { venueToast = nil }
             }
         }
-        .overlay(alignment: .top) {
+        .safeAreaInset(edge: .top) {
             if let t = venueToast {
                 VenueBanner(text: "\(t.name) • A4 \(String(format: "%.1f", t.a4)) Hz")
                     .transition(.move(edge: .top).combined(with: .opacity))
@@ -449,7 +452,6 @@ private let libraryStore = ScaleLibraryStore.shared
     private var latticeContent: some View {
         LatticeScreen()
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .padding(.top, -20)
     }
 
     private var tunerCardView: some View {

--- a/Tenney/ScreenShell.swift
+++ b/Tenney/ScreenShell.swift
@@ -1,0 +1,58 @@
+//
+//  ScreenShell.swift
+//  Tenney
+//
+//  Created by OpenAI on 2/27/25.
+//
+
+import SwiftUI
+
+struct ScreenShell<Background: View>: ViewModifier {
+    let background: Background
+
+    func body(content: Content) -> some View {
+        ZStack {
+            Color(.systemBackground)
+                .ignoresSafeArea()
+            background
+                .ignoresSafeArea()
+            content
+        }
+        .overlay(ScreenShellDebugOverlay())
+    }
+}
+
+extension View {
+    func screenShell<Background: View>(@ViewBuilder background: () -> Background = { EmptyView() }) -> some View {
+        modifier(ScreenShell(background: background()))
+    }
+}
+
+#if DEBUG
+private struct ScreenShellDebugOverlay: View {
+    static let enabled = false
+
+    var body: some View {
+        if Self.enabled {
+            GeometryReader { proxy in
+                VStack(spacing: 0) {
+                    Color.red.opacity(0.2)
+                        .frame(height: proxy.safeAreaInsets.top)
+                    Spacer(minLength: 0)
+                    Color.blue.opacity(0.2)
+                        .frame(height: proxy.safeAreaInsets.bottom)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            }
+            .ignoresSafeArea()
+            .allowsHitTesting(false)
+        }
+    }
+}
+#else
+private struct ScreenShellDebugOverlay: View {
+    var body: some View {
+        EmptyView()
+    }
+}
+#endif


### PR DESCRIPTION
### Motivation
- Eliminate blank/unpainted top/bottom safe-area strips and accidental content clipping on iPhone by providing a single app-wide background that always paints safe areas while keeping content respecting safe areas.
- Make navigation/tab chrome deterministic so translucent "glass-only" backgrounds no longer cause visual drift at the notch/home indicator.
- Keep change minimal and centralized so screens do not need per-screen patches and visual layout is preserved.

### Description
- Add `ScreenShell` view modifier and `View.screenShell()` extension that composes an opaque base (`Color(.systemBackground)`) plus an optional background view and renders content above it while only the background ignores safe areas (`Tenney/ScreenShell.swift`).
- Add a DEBUG-only, opt-in safe-area overlay to visualize top/bottom safe areas (`ScreenShellDebugOverlay`) controlled by a static `enabled` flag inside the shell.
- Apply `.screenShell { resolvedTheme.surfaceTint }` at the app root in `ContentView` so the theme surface tint paints behind all screens, and enable deterministic chrome with `.toolbarBackground(.visible, for: .navigationBar)` and `.toolbarBackground(.visible, for: .tabBar)`.
- Move the venue toast from a generic `.overlay` into a `.safeAreaInset(edge: .top)` to avoid banner clipping and remove a negative top padding on `LatticeScreen` so content respects the top safe area.

### Testing
- No automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970082a96708327b6d14cf01e64e2f2)