### PR TITLE
Premium redesign of Community Pack detail sheet; safe-area background + selective install/update

### DIFF
--- a/Tenney/CommunityInstallRegistry.swift
+++ b/Tenney/CommunityInstallRegistry.swift
@@ -3,6 +3,7 @@ import Combine
 
 struct CommunityInstallRecord: Codable, Hashable {
     var installedScaleIDs: [UUID]
+    var installedRemoteScaleIDs: [String]?
     var installedAt: Date
     var installedVersion: String
     var installedContentHash: String

--- a/Tenney/NoiseOverlay.swift
+++ b/Tenney/NoiseOverlay.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct NoiseOverlay: View {
+    let seed: Int
+    var opacity: Double = 0.05
+    var density: Int = 120
+
+    var body: some View {
+        Canvas { context, size in
+            var generator = SeededGenerator(seed: UInt64(truncatingIfNeeded: seed))
+            let step = max(1, Int(min(size.width, size.height) / CGFloat(density)))
+            let columns = max(1, Int(size.width) / step)
+            let rows = max(1, Int(size.height) / step)
+
+            for y in 0...rows {
+                for x in 0...columns {
+                    let value = Double.random(in: 0.0...1.0, using: &generator)
+                    let alpha = opacity * (0.35 + value * 0.65)
+                    let rect = CGRect(
+                        x: CGFloat(x * step),
+                        y: CGFloat(y * step),
+                        width: CGFloat(step),
+                        height: CGFloat(step)
+                    )
+                    context.fill(Path(rect), with: .color(Color.black.opacity(alpha)))
+                }
+            }
+        }
+        .blendMode(.overlay)
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+}
+
+private struct SeededGenerator: RandomNumberGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        self.state = seed == 0 ? 0xdecafbadcafebabe : seed
+    }
+
+    mutating func next() -> UInt64 {
+        state = state &* 2862933555777941757 &+ 3037000493
+        return state
+    }
+}

--- a/Tenney/PackVisualIdentity.swift
+++ b/Tenney/PackVisualIdentity.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+import UIKit
+
+enum PackVisualIdentity {
+    static let symbolNames: [String] = [
+        "music.quarternote.3",
+        "music.note.list",
+        "music.mic",
+        "music.note",
+        "music.note.tv",
+        "waveform",
+        "waveform.circle",
+        "waveform.path",
+        "dial.min",
+        "dial.medium",
+        "dial.max",
+        "metronome",
+        "metronome.fill",
+        "guitars",
+        "pianokeys",
+        "pianokeys.inverse",
+        "pianokeys.circle",
+        "slider.horizontal.3",
+        "slider.horizontal.below.rectangle",
+        "slider.vertical.3",
+        "circle.grid.cross",
+        "circle.grid.cross.fill",
+        "square.grid.3x3",
+        "triangle",
+        "triangle.fill",
+        "hexagon",
+        "hexagon.fill",
+        "circle.hexagonpath",
+        "circle.hexagonpath.fill",
+        "circle.dotted",
+        "circle.grid.2x2",
+        "circle.grid.2x2.fill",
+        "diamond",
+        "diamond.fill",
+        "seal",
+        "seal.fill",
+        "sparkle",
+        "sparkles",
+        "star.square",
+        "star.square.fill",
+        "shield.lefthalf.filled",
+        "shield.righthalf.filled",
+        "cube",
+        "cube.fill",
+        "pyramid",
+        "pyramid.fill",
+        "hifispeaker",
+        "hifispeaker.fill",
+        "dot.radiowaves.left.and.right",
+        "dot.radiowaves.forward",
+        "wave.3.forward",
+        "wave.3.left",
+        "wave.3.backward",
+        "circlebadge.2",
+        "waveform.badge.plus",
+        "waveform.badge.exclamationmark",
+        "circle.square",
+        "circle.square.fill"
+    ]
+
+    static let palette: [Color] = [
+        Color(red: 0.32, green: 0.40, blue: 0.84),
+        Color(red: 0.26, green: 0.58, blue: 0.72),
+        Color(red: 0.34, green: 0.66, blue: 0.54),
+        Color(red: 0.63, green: 0.58, blue: 0.32),
+        Color(red: 0.78, green: 0.53, blue: 0.34),
+        Color(red: 0.80, green: 0.38, blue: 0.45),
+        Color(red: 0.66, green: 0.36, blue: 0.68),
+        Color(red: 0.44, green: 0.44, blue: 0.68),
+        Color(red: 0.30, green: 0.52, blue: 0.76),
+        Color(red: 0.42, green: 0.64, blue: 0.80),
+        Color(red: 0.46, green: 0.57, blue: 0.42),
+        Color(red: 0.74, green: 0.64, blue: 0.48),
+        Color(red: 0.70, green: 0.46, blue: 0.40),
+        Color(red: 0.56, green: 0.42, blue: 0.58),
+        Color(red: 0.42, green: 0.46, blue: 0.52),
+        Color(red: 0.36, green: 0.36, blue: 0.40)
+    ]
+
+    static func identity(for packID: String, accent: Color) -> (symbol: String, colors: [Color]) {
+        let hash = stableSeed(for: packID)
+        let symbol = symbolNames[abs(hash) % symbolNames.count]
+        let accentHue = accent.hueComponent ?? 0.0
+
+        var paletteIndex = abs(hash / 7) % palette.count
+        var primary = palette[paletteIndex]
+        if let hue = primary.hueComponent {
+            let distance = abs(hue - accentHue)
+            if distance < 0.08 || distance > 0.92 {
+                paletteIndex = (paletteIndex + 2) % palette.count
+                primary = palette[paletteIndex]
+            }
+        }
+
+        let secondary = palette[(paletteIndex + 5) % palette.count].opacity(0.65)
+        let neutral = Color(.secondarySystemBackground).opacity(0.9)
+        return (symbol, [primary, secondary, neutral])
+    }
+
+    static func stableSeed(for value: String) -> Int {
+        var hash: UInt64 = 1469598103934665603
+        for byte in value.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1099511628211
+        }
+        return Int(truncatingIfNeeded: hash)
+    }
+}
+
+private extension Color {
+    var hueComponent: Double? {
+        let uiColor = UIColor(self)
+        var hue: CGFloat = 0
+        var saturation: CGFloat = 0
+        var brightness: CGFloat = 0
+        var alpha: CGFloat = 0
+        guard uiColor.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha) else {
+            return nil
+        }
+        return Double(hue)
+    }
+}

--- a/Tenney/PremiumModalSurface.swift
+++ b/Tenney/PremiumModalSurface.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+enum PremiumModalSurface {
+    static let background = Color(.systemGray6)
+    static let barBackground = background
+
+    static var subtleShadow: some View {
+        Color.black.opacity(0.08)
+    }
+
+    static func cardSurface(cornerRadius: CGFloat) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        return shape
+            .fill(background)
+            .overlay(glassOverlay(in: shape))
+            .shadow(color: Color.black.opacity(0.08), radius: 10, x: 0, y: 6)
+    }
+
+    @ViewBuilder
+    static func glassOverlay<S: Shape>(in shape: S) -> some View {
+        if #available(iOS 26.0, *) {
+            Color.clear.glassEffect(.regular, in: shape)
+        } else {
+            shape.fill(.ultraThinMaterial).opacity(0.65)
+        }
+    }
+}

--- a/Tenney/ScaleLibrarySheet.swift
+++ b/Tenney/ScaleLibrarySheet.swift
@@ -966,7 +966,7 @@ struct ScaleActionsSheet: View {
     @AppStorage(SettingsKeys.builderExportCustomA4Hz) private var customExportA4Hz: Double = 440.0
     @AppStorage("Tenney.SoundOn") private var soundOn: Bool = true
     @AppStorage(SettingsKeys.safeAmp) private var safeAmp: Double = 0.18
-    @State private var playback = ScaleSheetPlayback()
+    @State private var playback = ScalePreviewPlayer()
     @State private var page: Int = 0
     @State private var tagsDetent: PresentationDetent = .medium
     @State private var tagsEditorPresented: Bool = false
@@ -1684,127 +1684,6 @@ private struct PagePips: View {
     }
 }
 
-
-private enum ScalePlaybackMode: String, CaseIterable, Identifiable {
-    case arp
-    case chord
-    case drone
-
-    var id: String { rawValue }
-    var title: String {
-        switch self {
-        case .arp: return "Arp"
-        case .chord: return "Chord"
-        case .drone: return "Drone"
-        }
-    }
-}
-
-private final class ScaleSheetPlayback {
-    private var activeVoiceIDs: [Int] = []
-    private var token = UUID()
-    private var droneActive = false
-
-    func play(mode: ScalePlaybackMode, scale: TenneyScale, degrees: [RatioRef], focus: RatioRef?, safeAmp: Double) {
-        stop()
-        let newToken = UUID()
-        token = newToken
-
-        let rootHz = RatioMath.foldToAudible(scale.referenceHz)
-        let selected = focus ?? degrees.first
-        let amp = Float(safeAmp)
-
-        func startTone(_ freq: Double) -> Int {
-            let ownerKey = "scaleLibrary:\(scale.id.uuidString):\(UUID().uuidString)"
-            return ToneOutputEngine.shared.sustain(
-                freq: freq,
-                amp: amp,
-                owner: .other,
-                ownerKey: ownerKey,
-                attackMs: 6,
-                releaseMs: 120
-            )
-        }
-
-        func scheduleRelease(id: Int, after seconds: Double) {
-            DispatchQueue.main.asyncAfter(deadline: .now() + seconds) { [weak self] in
-                guard let self, self.token == newToken else { return }
-                ToneOutputEngine.shared.release(id: id, seconds: 0.06)
-                self.activeVoiceIDs.removeAll { $0 == id }
-            }
-        }
-
-        switch mode {
-        case .arp:
-            for (index, ratio) in degrees.enumerated() {
-                let delay = Double(index) * 0.18
-                DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-                    guard let self, self.token == newToken else { return }
-                    let hz = RatioMath.hz(rootHz: scale.referenceHz, p: ratio.p, q: ratio.q, octave: ratio.octave, fold: true)
-                    let id = startTone(hz)
-                    self.activeVoiceIDs.append(id)
-                    scheduleRelease(id: id, after: 0.22)
-                }
-            }
-        case .chord:
-            for ratio in degrees {
-                let hz = RatioMath.hz(rootHz: scale.referenceHz, p: ratio.p, q: ratio.q, octave: ratio.octave, fold: true)
-                let id = startTone(hz)
-                activeVoiceIDs.append(id)
-                scheduleRelease(id: id, after: 0.38)
-            }
-        case .drone:
-            let rootID = startTone(rootHz)
-            activeVoiceIDs.append(rootID)
-            scheduleRelease(id: rootID, after: 0.48)
-            if let selected {
-                let hz = RatioMath.hz(rootHz: scale.referenceHz, p: selected.p, q: selected.q, octave: selected.octave, fold: true)
-                let id = startTone(hz)
-                activeVoiceIDs.append(id)
-                scheduleRelease(id: id, after: 0.48)
-            }
-        }
-    }
-
-    func stop() {
-        droneActive = false
-        token = UUID()
-        for id in activeVoiceIDs {
-            ToneOutputEngine.shared.release(id: id, seconds: 0.0)
-        }
-        activeVoiceIDs.removeAll()
-    }
-    
-    func toggleDrone(rootHz: Double, focusHz: Double, safeAmp: Double) -> Bool {
-        if droneActive {
-            stop()
-            droneActive = false
-            return false
-        }
-
-        stop()
-        droneActive = true
-
-        let amp = Float(safeAmp)
-        func startTone(_ freq: Double) -> Int {
-            let ownerKey = "scaleLibrary:drone:\(UUID().uuidString)"
-            return ToneOutputEngine.shared.sustain(
-                freq: freq,
-                amp: amp,
-                owner: .other,
-                ownerKey: ownerKey,
-                attackMs: 6,
-                releaseMs: 120
-            )
-        }
-
-        let a = startTone(rootHz)
-        let b = startTone(focusHz)
-        activeVoiceIDs = [a, b]
-        return true
-    }
-
-}
 
 private struct TagEditorView: View {
     @ObservedObject private var library = ScaleLibraryStore.shared

--- a/Tenney/ScalePreviewPlayer.swift
+++ b/Tenney/ScalePreviewPlayer.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+enum ScalePlaybackMode: String, CaseIterable, Identifiable {
+    case arp
+    case chord
+    case drone
+
+    var id: String { rawValue }
+    var title: String {
+        switch self {
+        case .arp: return "Arp"
+        case .chord: return "Chord"
+        case .drone: return "Drone"
+        }
+    }
+}
+
+final class ScalePreviewPlayer {
+    private var activeVoiceIDs: [Int] = []
+    private var token = UUID()
+    private var droneActive = false
+
+    func play(mode: ScalePlaybackMode, scale: TenneyScale, degrees: [RatioRef], focus: RatioRef?, safeAmp: Double) {
+        stop()
+        let newToken = UUID()
+        token = newToken
+
+        let rootHz = RatioMath.foldToAudible(scale.referenceHz)
+        let selected = focus ?? degrees.first
+        let amp = Float(safeAmp)
+
+        func startTone(_ freq: Double) -> Int {
+            let ownerKey = "scaleLibrary:\(scale.id.uuidString):\(UUID().uuidString)"
+            return ToneOutputEngine.shared.sustain(
+                freq: freq,
+                amp: amp,
+                owner: .other,
+                ownerKey: ownerKey,
+                attackMs: 6,
+                releaseMs: 120
+            )
+        }
+
+        func scheduleRelease(id: Int, after seconds: Double) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + seconds) { [weak self] in
+                guard let self, self.token == newToken else { return }
+                ToneOutputEngine.shared.release(id: id, seconds: 0.06)
+                self.activeVoiceIDs.removeAll { $0 == id }
+            }
+        }
+
+        switch mode {
+        case .arp:
+            for (index, ratio) in degrees.enumerated() {
+                let delay = Double(index) * 0.18
+                DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                    guard let self, self.token == newToken else { return }
+                    let hz = RatioMath.hz(rootHz: scale.referenceHz, p: ratio.p, q: ratio.q, octave: ratio.octave, fold: true)
+                    let id = startTone(hz)
+                    self.activeVoiceIDs.append(id)
+                    scheduleRelease(id: id, after: 0.22)
+                }
+            }
+        case .chord:
+            for ratio in degrees {
+                let hz = RatioMath.hz(rootHz: scale.referenceHz, p: ratio.p, q: ratio.q, octave: ratio.octave, fold: true)
+                let id = startTone(hz)
+                activeVoiceIDs.append(id)
+                scheduleRelease(id: id, after: 0.38)
+            }
+        case .drone:
+            let rootID = startTone(rootHz)
+            activeVoiceIDs.append(rootID)
+            scheduleRelease(id: rootID, after: 0.48)
+            if let selected {
+                let hz = RatioMath.hz(rootHz: scale.referenceHz, p: selected.p, q: selected.q, octave: selected.octave, fold: true)
+                let id = startTone(hz)
+                activeVoiceIDs.append(id)
+                scheduleRelease(id: id, after: 0.48)
+            }
+        }
+    }
+
+    func stop() {
+        droneActive = false
+        token = UUID()
+        for id in activeVoiceIDs {
+            ToneOutputEngine.shared.release(id: id, seconds: 0.0)
+        }
+        activeVoiceIDs.removeAll()
+    }
+
+    func toggleDrone(rootHz: Double, focusHz: Double, safeAmp: Double) -> Bool {
+        if droneActive {
+            stop()
+            droneActive = false
+            return false
+        }
+
+        stop()
+        droneActive = true
+
+        let amp = Float(safeAmp)
+        func startTone(_ freq: Double) -> Int {
+            let ownerKey = "scaleLibrary:drone:\(UUID().uuidString)"
+            return ToneOutputEngine.shared.sustain(
+                freq: freq,
+                amp: amp,
+                owner: .other,
+                ownerKey: ownerKey,
+                attackMs: 6,
+                releaseMs: 120
+            )
+        }
+
+        let a = startTone(rootHz)
+        let b = startTone(focusHz)
+        activeVoiceIDs = [a, b]
+        return true
+    }
+}


### PR DESCRIPTION
### Motivation

- Replace the existing plain full-screen pack detail with a polished, poster-style premium surface and fix the persistent white/clipped top/bottom by making the sheet root and chrome use a single opaque gray token. 
- Provide a deterministic pack visual identity (symbol + palette), subtle noise, and a slow, accessible reveal animation for an Arc-level premium feel. 
- Clarify and implement precise install/update semantics so updates only modify currently installed scales and new remote scales are opt-in.

### Description

- Introduced a reusable premium modal surface token `PremiumModalSurface` that provides a single opaque `background`/`barBackground`, `cardSurface(cornerRadius:)` and subtle glass overlay so the entire sheet (including safe areas) paints the same gray tone. (new: `Tenney/PremiumModalSurface.swift`) 
- Added deterministic visual identity and procedural noise: `PackVisualIdentity` selects a curated SF Symbol + 2–3-color palette by stable hash and avoids collisions with the app accent, and `NoiseOverlay` draws a seeded, subtle noise canvas layered above the base background. (new: `Tenney/PackVisualIdentity.swift`, `Tenney/NoiseOverlay.swift`) 
- Added `ScalePreviewPlayer` as a shared helper to play short arp/chord/drone previews (the same engine used by `ScaleActionsSheet`) and wired it into the pack detail rows and action sheet to avoid stacking preview sheets. (new: `Tenney/ScalePreviewPlayer.swift`, updates to `Tenney/ScaleLibrarySheet.swift`) 
- Rebuilt `CommunityPackDetailView` to use `PremiumModalSurface.background.ignoresSafeArea()` + `NoiseOverlay`, unify top/bottom chrome with the body background, add a visible 44pt glass circle close button that toggles to a back chevron in selection mode, and a poster hero with deterministic symbol, curated palette, subtle stroke and parallax on scroll. (modified: `Tenney/CommunityPacksViews.swift`) 
- Implemented selection-mode state machine for Install and Update (`none`, `installSelecting`, `updateSelecting`) with per-scale checkboxes, primary action state, and toolbar subtitle reflecting selection count; play icon per row uses `ScalePreviewPlayer`. (modified: `Tenney/CommunityPacksViews.swift`) 
- Extended install/update persistence and semantics: `CommunityInstallRecord` now stores optional `installedRemoteScaleIDs`, `CommunityPacksStore.enqueueInstall(...)` accepts optional `selectedScaleIDs`, `performInstall` only imports selected scales, and `installedRemoteScaleIDs(for:)` resolves previously installed remote IDs. This enforces: updates affect installed scales only and new remote scales are optional. (modified: `Tenney/CommunityInstallRegistry.swift`, `Tenney/CommunityPacksStore.swift`) 
- Kept accessibility: animations respect `Reduce Motion`, reveal timing tuned to ~0.8s total, matched-geometry hero kept, and no reliance on clear presentation backgrounds so safe areas never appear white. 

### Testing

- No automated tests were executed as part of this change set; manual runtime verification is expected during QA to validate UI/animation, safe-area rendering, install/update flows, and preview playback.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970193c26c88327b75e4ca87c7c68a9)