### PR TITLE
Community Packs: sheet presentation, poster first sentence, matched-geometry fixes, and glass close button

### DIFF
--- a/Tenney/CommunityPacksViews.swift
+++ b/Tenney/CommunityPacksViews.swift
@@ -35,6 +35,28 @@ private func communityScaleForFiltering(pack: CommunityPackViewModel, scale: Com
     )
 }
 
+private func firstSentence(_ text: String) -> String {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return "" }
+    let terminators: Set<Character> = [".", "!", "?"]
+    var index = trimmed.startIndex
+    while index < trimmed.endIndex {
+        let character = trimmed[index]
+        if terminators.contains(character) {
+            let next = trimmed.index(after: index)
+            if next == trimmed.endIndex || trimmed[next].isWhitespace {
+                let sentence = String(trimmed[...index])
+                return sentence.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+        }
+        index = trimmed.index(after: index)
+    }
+    if let firstLine = trimmed.split(whereSeparator: \.isNewline).first {
+        return firstLine.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    return ""
+}
+
 struct CommunityPackBadge: View {
     let packName: String
 
@@ -129,12 +151,15 @@ struct CommunityPacksPageList: View {
                 await store.refresh(force: true)
             }
         }
-        .fullScreenCover(item: $selectedPack) { pack in
+        .sheet(item: $selectedPack) { pack in
             CommunityPackDetailView(
                 pack: pack,
                 namespace: packNamespace,
                 onPreviewRequested: onPreviewRequested
             )
+            .presentationDetents([.large])
+            .presentationDragIndicator(.hidden)
+            .presentationBackground(PremiumModalSurface.background)
         }
         .task {
             guard !didTriggerRefresh else { return }
@@ -277,18 +302,22 @@ private struct CommunityPacksSections: View {
                 ScrollView(.horizontal, showsIndicators: false) {
                     LazyHStack(spacing: 14) {
                         ForEach(featured) { pack in
-                            FeaturedPackCard(
-                                pack: pack,
-                                isInstalling: store.installingPackIDs.contains(pack.packID),
-                                updateAvailable: updateAvailable(pack),
-                                isInstalled: store.isInstalled(pack.packID),
-                                onOpen: { selectedPack = pack },
-                                onInstall: { store.enqueueInstall(pack: pack, action: action(for: pack)) },
-                                namespace: namespace
-                            )
-                            .frame(width: 280)
-                            .modifier(FeaturedScrollTransition())
-                            .opacity(selectedPack?.packID == pack.packID ? 0 : 1)
+                            let isSelected = selectedPack?.packID == pack.packID
+                            VStack(spacing: 0) {
+                                FeaturedPackCard(
+                                    pack: pack,
+                                    isInstalling: store.installingPackIDs.contains(pack.packID),
+                                    updateAvailable: updateAvailable(pack),
+                                    isInstalled: store.isInstalled(pack.packID),
+                                    isMatchedSource: isSelected,
+                                    onOpen: { selectedPack = pack },
+                                    onInstall: { store.enqueueInstall(pack: pack, action: action(for: pack)) },
+                                    namespace: namespace
+                                )
+                                .frame(width: 280)
+                                .modifier(FeaturedScrollTransition())
+                            }
+                            .opacity(isSelected ? 0 : 1)
                         }
                     }
                     .padding(.horizontal, 4)
@@ -304,16 +333,20 @@ private struct CommunityPacksSections: View {
             } else {
                 LazyVStack(spacing: 10) {
                     ForEach(installed) { pack in
-                        CompactPackCard(
-                            pack: pack,
-                            style: .installed,
-                            isInstalling: store.installingPackIDs.contains(pack.packID),
-                            updateAvailable: updateAvailable(pack),
-                            onOpen: { selectedPack = pack },
-                            onInstall: { store.enqueueInstall(pack: pack, action: .update) },
-                            namespace: namespace
-                        )
-                        .opacity(selectedPack?.packID == pack.packID ? 0 : 1)
+                        let isSelected = selectedPack?.packID == pack.packID
+                        VStack(spacing: 0) {
+                            CompactPackCard(
+                                pack: pack,
+                                style: .installed,
+                                isInstalling: store.installingPackIDs.contains(pack.packID),
+                                updateAvailable: updateAvailable(pack),
+                                isMatchedSource: isSelected,
+                                onOpen: { selectedPack = pack },
+                                onInstall: { store.enqueueInstall(pack: pack, action: .update) },
+                                namespace: namespace
+                            )
+                        }
+                        .opacity(isSelected ? 0 : 1)
                     }
                 }
             }
@@ -321,16 +354,20 @@ private struct CommunityPacksSections: View {
             SectionHeader(title: "Browse all")
             LazyVStack(spacing: 10) {
                 ForEach(browseAll) { pack in
-                    CompactPackCard(
-                        pack: pack,
-                        style: .browse,
-                        isInstalling: store.installingPackIDs.contains(pack.packID),
-                        updateAvailable: updateAvailable(pack),
-                        onOpen: { selectedPack = pack },
-                        onInstall: { store.enqueueInstall(pack: pack, action: .install) },
-                        namespace: namespace
-                    )
-                    .opacity(selectedPack?.packID == pack.packID ? 0 : 1)
+                    let isSelected = selectedPack?.packID == pack.packID
+                    VStack(spacing: 0) {
+                        CompactPackCard(
+                            pack: pack,
+                            style: .browse,
+                            isInstalling: store.installingPackIDs.contains(pack.packID),
+                            updateAvailable: updateAvailable(pack),
+                            isMatchedSource: isSelected,
+                            onOpen: { selectedPack = pack },
+                            onInstall: { store.enqueueInstall(pack: pack, action: .install) },
+                            namespace: namespace
+                        )
+                    }
+                    .opacity(isSelected ? 0 : 1)
                 }
             }
         }
@@ -374,6 +411,7 @@ private struct FeaturedPackCard: View {
     let isInstalling: Bool
     let updateAvailable: Bool
     let isInstalled: Bool
+    let isMatchedSource: Bool
     let onOpen: () -> Void
     let onInstall: () -> Void
     let namespace: Namespace.ID
@@ -418,7 +456,7 @@ private struct FeaturedPackCard: View {
         .padding(16)
         .background(
             PackCardSurface(cornerRadius: 24)
-                .matchedGeometryEffect(id: "pack-card-\(pack.packID)", in: namespace, isSource: true)
+                .matchedGeometryEffect(id: "pack-card-\(pack.packID)", in: namespace, isSource: isMatchedSource)
         )
         .overlay(
             RoundedRectangle(cornerRadius: 24, style: .continuous)
@@ -471,6 +509,7 @@ private struct CompactPackCard: View {
     let style: CompactPackCardStyle
     let isInstalling: Bool
     let updateAvailable: Bool
+    let isMatchedSource: Bool
     let onOpen: () -> Void
     let onInstall: () -> Void
     let namespace: Namespace.ID
@@ -512,7 +551,7 @@ private struct CompactPackCard: View {
         .padding(12)
         .background(
             PackCardSurface(cornerRadius: 16)
-                .matchedGeometryEffect(id: "pack-card-\(pack.packID)", in: namespace, isSource: true)
+                .matchedGeometryEffect(id: "pack-card-\(pack.packID)", in: namespace, isSource: isMatchedSource)
         )
         .overlay(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
@@ -695,6 +734,10 @@ private struct CommunityPackDetailView: View {
         return "Preview"
     }
 
+    private var isSelecting: Bool {
+        selectionMode != .none
+    }
+
     var body: some View {
         detailContent
     }
@@ -789,6 +832,7 @@ private struct CommunityPackDetailView: View {
                 .padding(.top, 8)
                 .padding(.bottom, 96)
             }
+            .scrollIndicators(.hidden)
             .safeAreaInset(edge: .top) { detailToolbar }
             .safeAreaInset(edge: .bottom) { detailActionBar }
             .coordinateSpace(name: "packDetailScroll")
@@ -803,6 +847,7 @@ private struct CommunityPackDetailView: View {
         .onDisappear {
             previewPlayer.stop()
         }
+        .interactiveDismissDisabled(isSelecting)
         .presentationBackground(PremiumModalSurface.background)
         .confirmationDialog(
             "Some scales already exist in your Library.",
@@ -831,6 +876,7 @@ private struct CommunityPackDetailView: View {
     private var headerCard: some View {
         let identity = PackVisualIdentity.identity(for: pack.packID, accent: .accentColor)
         let parallax = max(min(-scrollOffset / 10, 12), -12)
+        let posterDescription = firstSentence(pack.description)
         return VStack(alignment: .leading, spacing: 16) {
             HStack(alignment: .top, spacing: 16) {
                 VStack(alignment: .leading, spacing: 8) {
@@ -839,11 +885,12 @@ private struct CommunityPackDetailView: View {
                     Text("by \(pack.authorName)")
                         .font(.title3.weight(.medium))
                         .foregroundStyle(.secondary)
-                    if !pack.description.isEmpty {
-                        Text(pack.description)
+                    if !posterDescription.isEmpty {
+                        Text(posterDescription)
                             .font(.callout)
                             .foregroundStyle(.secondary)
-                            .lineLimit(1)
+                            .lineLimit(2)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                 }
                 Spacer()
@@ -965,24 +1012,7 @@ private struct CommunityPackDetailView: View {
                     .foregroundStyle(.secondary)
             }
             Spacer()
-            Button(action: handleCloseTap) {
-                Image(systemName: selectionMode == .none ? "xmark" : "chevron.left")
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundStyle(.primary)
-                    .frame(width: 44, height: 44)
-                    .background(
-                        Circle()
-                            .fill(PremiumModalSurface.background)
-                            .overlay(PremiumModalSurface.glassOverlay(in: Circle()))
-                            .overlay(
-                                Circle()
-                                    .stroke(Color.secondary.opacity(0.28), lineWidth: 1)
-                            )
-                    )
-                    .contentShape(Circle())
-                    .accessibilityLabel(selectionMode == .none ? "Close" : "Back")
-            }
-            .buttonStyle(.plain)
+            GlassRedCircleButton(isSelecting: isSelecting, action: handleCloseTap)
         }
         .padding(.horizontal, 16)
         .padding(.top, 10)
@@ -1349,10 +1379,18 @@ private struct CommunityPackDetailView: View {
                     RoundedRectangle(cornerRadius: 18, style: .continuous)
                         .stroke(Color.white.opacity(0.25), lineWidth: 1)
                 )
+            Circle()
+                .fill(.ultraThinMaterial)
+                .overlay(
+                    Circle()
+                        .stroke(Color.white.opacity(0.2), lineWidth: 1)
+                )
+                .frame(width: 52, height: 52)
             Image(systemName: symbol)
-                .font(.system(size: 40, weight: .semibold))
+                .font(.system(size: 50, weight: .semibold))
                 .symbolRenderingMode(.palette)
                 .foregroundStyle(colors[0], colors[1], colors.count > 2 ? colors[2] : Color.white)
+                .opacity(0.95)
                 .offset(y: parallax)
                 .ifAvailableSymbolEffect(symbolDrawn)
         }

--- a/Tenney/GlassRedCircleButton.swift
+++ b/Tenney/GlassRedCircleButton.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct GlassRedCircleButton: View {
+    let isSelecting: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: isSelecting ? "chevron.left" : "xmark")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(.primary)
+                .frame(width: 44, height: 44)
+                .background(glassBackground)
+                .overlay(
+                    Circle()
+                        .stroke(Color.red.opacity(0.5), lineWidth: 1)
+                )
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .tint(.red)
+        .accessibilityLabel(isSelecting ? "Back" : "Close")
+    }
+
+    @ViewBuilder
+    private var glassBackground: some View {
+        if #available(iOS 26.0, *) {
+            Color.clear.glassEffect(.regular, in: Circle())
+        } else {
+            Circle()
+                .fill(.ultraThinMaterial)
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent ghosting/duplicate card artifacts when opening pack details and make the sheet presentation match the app's modal surface. 
- Improve hero poster readability by showing the first full sentence of the pack description. 
- Ensure the hero symbol is visible and the toolbar control is a consistent 44pt glass red circle that toggles to a back chevron in selection mode. 

### Description

- Switched pack detail presentation from `fullScreenCover(item:)` to `sheet(item:)` with `.presentationDetents([.large])`, `.presentationDragIndicator(.hidden)`, and `.presentationBackground(PremiumModalSurface.background)` to provide an opaque modal background. 
- Added `firstSentence(_:)` helper and used `let posterDescription = firstSentence(pack.description)` in `CommunityPackDetailView` header, rendering it with `.lineLimit(2)` and `.fixedSize(horizontal: false, vertical: true)`. 
- Hid the tapped pack at the outermost cell container by wrapping featured/compact cards in a `VStack` and applying `.opacity(isSelected ? 0 : 1)`, and added `isMatchedSource` to `FeaturedPackCard`/`CompactPackCard` so `matchedGeometryEffect(..., isSource:)` is `true` only for the selected card. 
- Ensured hero symbol is a foreground layer above the gradient, used `.symbolRenderingMode(.palette)` with `.foregroundStyle(...)`, increased font size to ~50 and added a subtle circular plate behind the symbol to protect contrast. 
- Hid scroll indicators in the detail `ScrollView` with `.scrollIndicators(.hidden)` and disabled interactive sheet dismissal while in selection mode via `.interactiveDismissDisabled(isSelecting)`. 
- Introduced `GlassRedCircleButton` (new `Tenney/GlassRedCircleButton.swift`) implementing the 44×44 glass red circle button whose icon toggles between `xmark` and `chevron.left`, and replaced the previous toolbar close control with this component. 

Files changed: `Tenney/CommunityPacksViews.swift` (modifications) and `Tenney/GlassRedCircleButton.swift` (new). 

### Testing

- Automated tests: none executed for this UI-only change. 
- Manual verification notes: code compiles in the working tree; UI behavior changes implemented as described (sheet detent, poster text, symbol plate, matched-geometry source control, hidden scroll indicators, and new glass close/back button).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697025d068f4832783dca0a255080df5)