### PR TITLE
Use shared GlassRedCircle for pack sheet toolbar and fix hero symbol layering

### DIFF
--- a/Tenney/GlassRedCircle.swift
+++ b/Tenney/GlassRedCircle.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct GlassRedCircle: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, macOS 15.0, *) {
+            content
+                .background(
+                    Color.clear
+                        .glassEffect(.regular.tint(.red), in: Circle())
+                )
+        } else {
+            content
+                .background(.ultraThinMaterial, in: Circle())
+                .overlay(Circle().fill(Color.red.opacity(0.22)))
+                .overlay(Circle().stroke(Color.white.opacity(0.16), lineWidth: 1))
+        }
+    }
+}

--- a/Tenney/ScaleBuilderScreen.swift
+++ b/Tenney/ScaleBuilderScreen.swift
@@ -29,22 +29,6 @@ struct ScaleBuilderScreen: View {
         (themeStyleRaw == "dark") || (themeStyleRaw == "system" && systemScheme == .dark)
     }
     
-    private struct GlassRedCircle: ViewModifier {
-        func body(content: Content) -> some View {
-            if #available(iOS 26.0, macOS 15.0, *) {
-                content
-                    .background(
-                        Color.clear
-                            .glassEffect(.regular.tint(.red), in: Circle())
-                    )
-            } else {
-                content
-                    .background(.ultraThinMaterial, in: Circle())
-                    .overlay(Circle().fill(Color.red.opacity(0.22)))
-                    .overlay(Circle().stroke(Color.white.opacity(0.16), lineWidth: 1))
-            }
-        }
-    }
     private func finishBuilder() {
         persistBuilderDraftToSession(reason: "done")
         didPersistOnDismiss = true


### PR DESCRIPTION
### Motivation

- Ensure the pack detail toolbar uses the repository's existing 44×44 red glass control and not a duplicated component. 
- Make the hero SF Symbol render deterministically above its gradient background using palette rendering. 
- Retain previous UI improvements (sheet presentation, poster text trimming, matched-geometry source control) while fixing the two issues above.

### Description

- Replaced the custom toolbar control with a plain `Button` that uses the shared `GlassRedCircle` modifier and a 44×44 frame, showing `xmark` normally and `chevron.left` while selecting, and wired it to `handleCloseTap` in `CommunityPackDetailView` (keeps selection-mode behavior). 
- Removed the duplicated `GlassRedCircleButton` file and moved the red-glass modifier into a shared `Tenney/GlassRedCircle.swift` `ViewModifier`, and removed the private inline `GlassRedCircle` from `ScaleBuilderScreen`. 
- Isolated the poster/icon rendering into a new `PackHeroSymbolView` inside `CommunityPacksViews.swift` which places the gradient background below an `iconLayer` and applies modifiers to the `Image(systemName:)` in the correct order (`.font`, `.symbolRenderingMode(.palette)`, `.foregroundStyle(...)`, `.opacity(1)`, `.blendMode(.normal)`, `.compositingGroup()`), with a subtle circular plate behind the symbol to protect contrast. 
- Continued earlier UI refinements: switched detail presentation to `sheet(item:)` with `.presentationDetents([.large])`, `.presentationDragIndicator(.hidden)`, `.presentationBackground(PremiumModalSurface.background)`, added `firstSentence(_:)` for poster text trimming, threaded `isMatchedSource` into pack cards to control `matchedGeometryEffect`, hid scroll indicators in detail `ScrollView`, and disabled interactive dismissal while selecting via `.interactiveDismissDisabled(isSelecting)`.

### Testing

- Automated tests: none executed for these UI-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697025d068f4832783dca0a255080df5)