### PR TITLE
Fix community pack hero SF Symbol rendering

### DIFF
--- a/Tenney/CommunityPacksViews.swift
+++ b/Tenney/CommunityPacksViews.swift
@@ -1551,6 +1551,7 @@ private struct PackHeroSymbolView: View {
     }
 
     private var iconLayer: some View {
+        let resolvedName = PackVisualIdentity.resolvedSymbolName(symbolName)
         ZStack {
             Circle()
                 .fill(.ultraThinMaterial)
@@ -1560,8 +1561,8 @@ private struct PackHeroSymbolView: View {
                 )
                 .frame(width: 52, height: 52)
 
-            Image(systemName: symbolName)
-                .font(.system(size: 52, weight: .semibold))
+            Image(systemName: resolvedName)
+                .font(.system(size: 54, weight: .semibold))
                 .symbolRenderingMode(.palette)
                 .foregroundStyle(colors[0], colors[1], colors.count > 2 ? colors[2] : colors[0])
                 .opacity(1)


### PR DESCRIPTION
### Motivation
- The community pack hero icon could disappear (only the gradient showed), likely because some curated SF Symbol names aren't available on the runtime or the identity colors were unintentionally translucent, causing the glyph to be invisible or masked.

### Description
- Filter the curated SF Symbol list and pick only available symbols at runtime, falling back to a safe name (`"music.note"`) when necessary via `resolvedSymbolName(_:)` and `isSymbolAvailable(_:)` (uses `UIImage` / `NSImage`).
- Use the resolved symbol name when rendering the hero image in `PackHeroSymbolView` and apply the image modifiers (`.font()`, `.symbolRenderingMode(.palette)`, `.foregroundStyle(...)`, `.blendMode(.normal)`, `.compositingGroup()`) to keep the glyph isolated and stable; slightly adjusted glyph font sizing for visibility.
- Clamp identity palette alpha via `ensureVisible(_:)` so returned colors are not effectively transparent and extend `hueComponent` to support AppKit.
- Add conditional `AppKit` import and minimal platform checks so symbol availability and color handling work across platforms.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69702c69ebfc8327a6863b267c116a22)