### PR TITLE
Use verified SF Symbols for pack hero icon

### DIFF
--- a/Tenney/PackVisualIdentity.swift
+++ b/Tenney/PackVisualIdentity.swift
@@ -92,10 +92,10 @@ enum PackVisualIdentity {
         Color(red: 0.36, green: 0.36, blue: 0.40)
     ]
 
-    static func identity(for packID: String, accent: Color) -> (symbol: String, colors: [Color]) {
+    static func identity(for packID: String, accent: Color) -> (symbolName: String, palette: [Color]) {
         let hash = stableSeed(for: packID)
         let symbolCandidate = symbolNames[abs(hash) % symbolNames.count]
-        let symbol = resolvedSymbolName(symbolCandidate)
+        let symbolName = resolvedSymbolName(symbolCandidate)
         let accentHue = accent.hueComponent ?? 0.0
 
         var paletteIndex = abs(hash / 7) % palette.count
@@ -110,8 +110,8 @@ enum PackVisualIdentity {
 
         let secondary = palette[(paletteIndex + 5) % palette.count].opacity(0.65)
         let neutral = Color(.secondarySystemBackground).opacity(0.9)
-        let colors = [primary, secondary, neutral].map { ensureVisible($0) }
-        return (symbol, colors)
+        let palette = [primary, secondary, neutral].map { ensureVisible($0) }
+        return (symbolName, palette)
     }
 
     static func stableSeed(for value: String) -> Int {


### PR DESCRIPTION
### Motivation
- Replace the custom vector/SVG-based hero mark with an end-to-end SF Symbol rendering so the hero always uses system symbols and no SVG fallback is used. 
- Keep the hero deterministic (hash-based) and retain the color palette/gradient plate while improving robustness across UIKit/AppKit. 

### Description
- Changed `PackVisualIdentity.identity(for:accent:)` to return `(symbolName: String, palette: [Color])` and kept the deterministic selection and visibility adjustments in `Tenney/PackVisualIdentity.swift`.
- Switched the hero invocation in `Tenney/CommunityPacksViews.swift` to use `identity.symbolName` and `identity.palette` when building the hero tile.
- Replaced the previous custom symbol renderer with `VerifiedSFSymbol`, which resolves a valid SF Symbol (falls back to `music.note` if unavailable), creates a configured symbol image via `UIImage.SymbolConfiguration` or `NSImage.SymbolConfiguration` and renders it as an image with `.renderingMode(.original)` while insulating compositing via `.compositingGroup()`, `.opacity(1)`, and `.blendMode(.normal)`.
- Implemented macOS (`AppKit`) handling with palette config and an additional hierarchical-color fallback when palette-based configuration fails, and set the symbol point size to `56` and weight to `.semibold`.

### Testing
- No automated tests were executed as part of this change (no unit/UI tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970379767748327823bdfb587c6b9f8)