### PR TITLE
Hero poster SF Symbol: white monochrome overlay & subtle underlay

### DIFF
--- a/Tenney/CommunityPacksViews.swift
+++ b/Tenney/CommunityPacksViews.swift
@@ -1548,23 +1548,30 @@ private struct PackHeroSymbolView: View {
     }
 
     private var iconLayer: some View {
-        let palette = [
-            colors.first ?? .accentColor,
-            colors.dropFirst().first ?? colors.first ?? .accentColor,
-            colors.dropFirst(2).first ?? colors.first ?? .accentColor
-        ]
+        let resolvedSymbolName = VerifiedSFSymbol.resolvedSymbolName(for: symbolName)
         return ZStack {
-            VerifiedSFSymbol(
-                symbolName: symbolName,
-                palette: palette,
-                pointSize: 56
-            )
+            Image(systemName: resolvedSymbolName)
+                .symbolRenderingMode(.monochrome)
+                .foregroundStyle(.white.opacity(0.18))
+                .font(.system(size: 56, weight: .semibold, design: .default))
+                .blur(radius: 0.6)
+
+            Image(systemName: resolvedSymbolName)
+                .symbolRenderingMode(.monochrome)
+                .foregroundStyle(.white)
+                .font(.system(size: 56, weight: .semibold, design: .default))
+                .opacity(0.94)
+                .blendMode(.overlay)
+                .shadow(color: .black.opacity(0.18), radius: 10, x: 0, y: 6)
         }
+        .compositingGroup()
+        .zIndex(20)
     }
 }
 
 private struct VerifiedSFSymbol: View {
-    private let fallbackSymbolName = "music.note"
+    private static let fallbackSymbolName = "music.note"
+    private let fallbackSymbolName = VerifiedSFSymbol.fallbackSymbolName
     let symbolName: String
     let palette: [Color]
     let pointSize: CGFloat
@@ -1592,6 +1599,10 @@ private struct VerifiedSFSymbol: View {
     }
 
     private var resolvedSymbolName: String {
+        Self.resolvedSymbolName(for: symbolName)
+    }
+
+    static func resolvedSymbolName(for symbolName: String) -> String {
         #if canImport(UIKit)
         if UIImage(systemName: symbolName) != nil {
             return symbolName


### PR DESCRIPTION
### Motivation
- Ensure the hero/poster SF Symbol appears as a white monochrome glyph (no palette tinting) so it reads consistently over the poster gradient. 
- Add the Arc poster overlay blend, subtle shadow, and a faint underlay to improve legibility on bright gradient stops. 
- Apply these changes surgically to the hero icon only while preserving existing symbol validation and fallback behavior.

### Description
- Replaced the palette-based `VerifiedSFSymbol` usage in `PackHeroSymbolView.iconLayer` with a two-layer `ZStack` that uses `Image(systemName: resolvedSymbolName)` for the underlay and main glyph. 
- Applied `.symbolRenderingMode(.monochrome)`, `.foregroundStyle(.white.opacity(0.18))` + `.blur(radius: 0.6)` for the faint underlay, and `.foregroundStyle(.white)`, `.opacity(0.94)`, `.blendMode(.overlay)`, and `.shadow(color: .black.opacity(0.18), radius: 10, x: 0, y: 6)` on the main glyph, plus `.font(.system(size: 56, weight: .semibold, design: .default))` to match sizing. 
- Wrapped the two layers with `.compositingGroup()` and `.zIndex(20)` to isolate rendering and keep the hero above gradient/noise layers. 
- Added `VerifiedSFSymbol.resolvedSymbolName(for:)` to reuse existing symbol name validation and kept the `music.note` fallback; the `VerifiedSFSymbol` view remains available for non-hero usages so palette rendering is preserved elsewhere.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69703e289b388327babc210606c4475d)