### PR TITLE
Fix community pack detail bottom padding

### DIFF
--- a/Tenney/CommunityPacksViews.swift
+++ b/Tenney/CommunityPacksViews.swift
@@ -705,6 +705,7 @@ private struct CommunityPackDetailView: View {
     @State private var pendingAction: CommunityPacksStore.InstallAction = .install
     @State private var pendingScaleIDs: Set<String> = []
     @State private var scrollOffset: CGFloat = 0
+    @State private var actionBarHeight: CGFloat = 0
     @State private var previewPlayer = ScalePreviewPlayer()
 
     private enum SelectionMode {
@@ -832,7 +833,7 @@ private struct CommunityPackDetailView: View {
                 }
                 .padding(.horizontal, 16)
                 .padding(.top, 8)
-                .padding(.bottom, 96)
+                .padding(.bottom, max(actionBarHeight + 16, 16))
             }
             .scrollIndicators(.hidden)
             .safeAreaInset(edge: .top) { detailToolbar }
@@ -841,6 +842,7 @@ private struct CommunityPackDetailView: View {
             .onPreferenceChange(ScrollOffsetPreferenceKey.self) { offset in
                 scrollOffset = offset
             }
+            .onPreferenceChange(ActionBarHeightKey.self) { actionBarHeight = $0 }
         }
         .onAppear(perform: startReveal)
         .onDisappear {
@@ -1120,6 +1122,11 @@ private struct CommunityPackDetailView: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
         .background(barBackground(separatorEdge: .top))
+        .background(
+            GeometryReader { proxy in
+                Color.clear.preference(key: ActionBarHeightKey.self, value: proxy.size.height)
+            }
+        )
         .opacity(contentVisible ? 1 : 0)
     }
 
@@ -1678,5 +1685,13 @@ private struct ScrollOffsetPreferenceKey: PreferenceKey {
 
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = nextValue()
+    }
+}
+
+private struct ActionBarHeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
     }
 }


### PR DESCRIPTION
### Motivation
- The scroll content in the Community Pack detail sheet reserved a hardcoded bottom gap (`.padding(.bottom, 96)`), which combined with `safeAreaInset(edge: .bottom)` produced a visible blank card-like area below the last section. 
- The goal is to keep the pinned action bar via `safeAreaInset(edge: .bottom)` while removing the extra empty surface and preserving visual design and hidden scroll indicators.

### Description
- Replaced the hardcoded bottom padding with a dynamic padding driven by the actual action bar height by adding `@State private var actionBarHeight: CGFloat = 0` to the view state in `Tenney/CommunityPacksViews.swift`.
- Introduced a small preference key `ActionBarHeightKey` and wired a `GeometryReader` onto `detailActionBar` to publish its height via `Color.clear.preference(key: ActionBarHeightKey.self, value: proxy.size.height)`.
- Consumed the preference with `.onPreferenceChange(ActionBarHeightKey.self) { actionBarHeight = $0 }` and changed the content padding to `.padding(.bottom, max(actionBarHeight + 16, 16))` so the scroll content has precise breathing room (16pt minimum) above the pinned bar.
- Kept `safeAreaInset(edge: .bottom) { detailActionBar }` and `.scrollIndicators(.hidden)` unchanged and only modified `Tenney/CommunityPacksViews.swift` to minimize risk of regressions.

### Testing
- No automated tests were executed for this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970428f8e2883278cfc7fe343f7143e)