### PR TITLE
Make community pack sheet full glass shell

### DIFF
--- a/Tenney/CommunityPacksViews.swift
+++ b/Tenney/CommunityPacksViews.swift
@@ -747,7 +747,10 @@ private struct CommunityPackDetailView: View {
 
     private var detailContent: some View {
         ZStack {
-            PremiumModalSurface.background
+            PremiumModalSurface.baseFill
+                .ignoresSafeArea()
+
+            PremiumModalSurface.glassOverlay(in: Rectangle())
                 .ignoresSafeArea()
 
             NoiseOverlay(seed: PackVisualIdentity.stableSeed(for: pack.packID), opacity: 0.04)
@@ -1132,7 +1135,7 @@ private struct CommunityPackDetailView: View {
 
     private func barBackground(separatorEdge: VerticalEdge) -> some View {
         PremiumModalSurface.barBackground
-            .overlay(PremiumModalSurface.glassOverlay(in: Rectangle()))
+            .overlay(PremiumModalSurface.barOverlayMaterial)
             .overlay(
                 Rectangle()
                     .fill(Color.secondary.opacity(0.16))

--- a/Tenney/PremiumModalSurface.swift
+++ b/Tenney/PremiumModalSurface.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
 enum PremiumModalSurface {
-    static let background = Color(.systemGray6)
-    static let barBackground = background
+    static let baseFill = Color(.secondarySystemBackground)
+    static let background = baseFill
+    static let barBackground = Color.clear
 
     static var subtleShadow: some View {
         Color.black.opacity(0.08)
@@ -14,6 +15,15 @@ enum PremiumModalSurface {
             .fill(background)
             .overlay(glassOverlay(in: shape))
             .shadow(color: Color.black.opacity(0.08), radius: 10, x: 0, y: 6)
+    }
+
+    @ViewBuilder
+    static var barOverlayMaterial: some View {
+        if #available(iOS 26.0, *) {
+            Color.clear
+        } else {
+            Rectangle().fill(.ultraThinMaterial).opacity(0.35)
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
### Motivation
- Make the Community Pack detail sheet render as a single continuous glass surface (including safe areas) without introducing white seams or translucency ghosting.  
- Preserve the existing `PremiumModalSurface` token as the base while evolving it to support a glass shell and graceful fallback for < iOS 26.

### Description
- Evolve `PremiumModalSurface` by introducing an opaque `baseFill` (`Color(.secondarySystemBackground)`), keep `background` pointing to it, and set `barBackground` to clear to avoid competing fills.  
- Add `barOverlayMaterial` to provide a subtle local material fallback on < iOS 26 while remaining clear on iOS 26+, and keep `glassOverlay(in:)` as the single glass host used by card surfaces.  
- Apply a full-screen glass shell in the pack detail sheet by using `PremiumModalSurface.baseFill` + `PremiumModalSurface.glassOverlay(in: Rectangle())` with `ignoresSafeArea()`, and replace toolbar/action bar backgrounds to use `PremiumModalSurface.barOverlayMaterial` (removing separate conflicting fills) so inset bars match the glass shell and avoid seams.  
- Keep the sheet presentation background as `presentationBackground(PremiumModalSurface.background)` so the opaque base prevents underlying list bleed while the glass effect is supplied by the full-screen overlay.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970445885c083279a22d911cf5396dd)