### PR TITLE
Make detail toolbar/action bar background transparent and keep only divider

### DIFF
--- a/Tenney/CommunityPacksViews.swift
+++ b/Tenney/CommunityPacksViews.swift
@@ -1134,14 +1134,12 @@ private struct CommunityPackDetailView: View {
     }
 
     private func barBackground(separatorEdge: VerticalEdge) -> some View {
-        PremiumModalSurface.barBackground
-            .overlay(PremiumModalSurface.barOverlayMaterial)
-            .overlay(
-                Rectangle()
-                    .fill(Color.secondary.opacity(0.16))
-                    .frame(height: 1),
-                alignment: separatorEdge == .top ? .top : .bottom
-            )
+        Color.clear.overlay(
+            Rectangle()
+                .fill(Color.secondary.opacity(0.16))
+                .frame(height: 1),
+            alignment: separatorEdge == .top ? .top : .bottom
+        )
     }
 
     private var trimmedChangelog: String {


### PR DESCRIPTION
### Motivation
- Prevent the toolbar and action bar from drawing a card-like filled surface under the global glass shell so the bottom blank card visual regression is removed and the bars rely on the shared shell fill.

### Description
- Replace `PremiumModalSurface.barBackground`/`PremiumModalSurface.barOverlayMaterial` usage in `barBackground(separatorEdge:)` with `Color.clear` and a single divider `Rectangle` so the bars no longer paint a full surface fill and only render the separator stroke.
- Change is confined to `Tenney/CommunityPacksViews.swift` and does not alter height measurement or `safeAreaInset` placement.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697047b6116483278131407fd8a8d8da)