### PR TITLE
Fix GlassDismissCircleButton glass rendering in Settings overlay

### DIFF
--- a/Tenney/Components/GlassDismissCircleButton.swift
+++ b/Tenney/Components/GlassDismissCircleButton.swift
@@ -6,14 +6,15 @@ struct GlassDismissCircleButton: View {
     var body: some View {
         Button(action: action) {
             ZStack {
-                Circle()
-                    .modifier(GlassBlueCircle())
+                // Diagnosis: applying GlassBlueCircle to a Circle fills it with .primary,
+                // which blocks the glass background (seen as "clear" in Settings).
                 Image(systemName: "checkmark")
                     .font(.system(size: 18, weight: .bold))
                     .foregroundStyle(.white)
             }
             .frame(width: 44, height: 44)
             .contentShape(Circle())
+            .modifier(GlassBlueCircle())
         }
         .buttonStyle(.plain)
     }


### PR DESCRIPTION
### Motivation
- Restore the visible blue glass plate for the Settings sheet top-trailing dismiss control which regressed to a clear circle because the glass modifier was applied in the wrong place.

### Description
- Move the `.modifier(GlassBlueCircle())` call from the inner `Circle()` to the dismiss button container in `Tenney/Components/GlassDismissCircleButton.swift` and add a short inline diagnosis comment explaining the issue.

### Testing
- No automated tests were executed in this environment; iOS build and UI verification were not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697130fe5ae88327b9bc39b72ecf4aec)