### PR TITLE
Fix CommunityPacks actor isolation; add AudioSessionController + Pro Audio UI and engine safety helpers

### DIFF
--- a/Tenney/CommunityPacksStore.swift
+++ b/Tenney/CommunityPacksStore.swift
@@ -921,14 +921,14 @@ final class CommunityPacksStore: ObservableObject {
     }
 
     #if DEBUG
-    private static func logFetch(_ message: String) { print(message) }
+    nonisolated private static func logFetch(_ message: String) { print(message) }
     #else
-    private static func logFetch(_ message: String) { }
+    nonisolated private static func logFetch(_ message: String) { }
     #endif
 
     private func logFetch(_ message: String) { Self.logFetch(message) }
 
-    private static func decodeSchema<T: Decodable>(
+    nonisolated private static func decodeSchema<T: Decodable>(
         _ type: T.Type,
         data: Data,
         label: String,
@@ -960,7 +960,7 @@ final class CommunityPacksStore: ObservableObject {
         }
     }
 
-    private static func decodeScalePayload(
+    nonisolated private static func decodeScalePayload(
         data: Data,
         label: String,
         assumedSchemaVersion: Int?,
@@ -978,7 +978,7 @@ final class CommunityPacksStore: ObservableObject {
         }
     }
 
-    private static func decodeSchemaOffMain<T: Decodable>(
+    nonisolated private static func decodeSchemaOffMain<T: Decodable>(
         _ type: T.Type,
         data: Data,
         label: String,
@@ -996,7 +996,7 @@ final class CommunityPacksStore: ObservableObject {
         }.value
     }
 
-    private static func decodeScalePayloadOffMain(
+    nonisolated private static func decodeScalePayloadOffMain(
         data: Data,
         label: String,
         assumedSchemaVersion: Int?,
@@ -1116,7 +1116,7 @@ final class CommunityPacksStore: ObservableObject {
         return String(format: "0x%02x", byte)
     }
 
-    private static func logSchemaMismatch(label: String, data: Data) {
+    nonisolated private static func logSchemaMismatch(label: String, data: Data) {
         var versionDescription = "missing"
         if let object = try? JSONSerialization.jsonObject(with: data),
            let dict = object as? [String: Any] {
@@ -1127,7 +1127,7 @@ final class CommunityPacksStore: ObservableObject {
         Self.logFetch("CommunityPacks \(label) schema mismatch (schemaVersion: \(versionDescription)).")
     }
 
-    private static func logDecodingError(label: String, error: DecodingError, data: Data) {
+    nonisolated private static func logDecodingError(label: String, error: DecodingError, data: Data) {
         let path = Self.decodingPath(from: error)
         Self.logFetch("CommunityPacks \(label) decode error at \(path.isEmpty ? "<root>" : path): \(error.localizedDescription)")
         if let object = try? JSONSerialization.jsonObject(with: data) {
@@ -1140,7 +1140,7 @@ final class CommunityPacksStore: ObservableObject {
         }
     }
 
-    private static func decodingPath(from error: DecodingError) -> String {
+    nonisolated private static func decodingPath(from error: DecodingError) -> String {
         let path: [CodingKey]
         switch error {
         case .typeMismatch(_, let context):
@@ -1157,7 +1157,7 @@ final class CommunityPacksStore: ObservableObject {
         return path.map(\.stringValue).joined(separator: ".")
     }
 
-    private static func injectSchemaVersionIfNeeded(
+    nonisolated private static func injectSchemaVersionIfNeeded(
         data: Data,
         label: String,
         assumedSchemaVersion: Int?,
@@ -1293,7 +1293,7 @@ final class CommunityPacksStore: ObservableObject {
         return (packData, scaleDataByPath)
     }
 
-    private static func communityPacksDecoder() -> JSONDecoder {
+    nonisolated private static func communityPacksDecoder() -> JSONDecoder {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
@@ -1320,13 +1320,13 @@ final class CommunityPacksStore: ObservableObject {
         return decoder
     }
 
-    private static let iso8601FractionalFormatter: ISO8601DateFormatter = {
+    nonisolated private static let iso8601FractionalFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return formatter
     }()
 
-    private static let iso8601Formatter: ISO8601DateFormatter = {
+    nonisolated private static let iso8601Formatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
         return formatter

--- a/Tenney/Components/AudioSessionController.swift
+++ b/Tenney/Components/AudioSessionController.swift
@@ -1,0 +1,412 @@
+//
+//  AudioSessionController.swift
+//  Tenney
+//
+//  Shared audio routing/controller surface for Pro Audio Settings.
+//
+
+import AVFoundation
+import Foundation
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
+
+@MainActor
+final class AudioSessionController: ObservableObject {
+    static let shared = AudioSessionController()
+
+    enum EngineState: Equatable {
+        case active
+        case stopped
+        case interrupted
+        case error(String)
+
+        var label: String {
+            switch self {
+            case .active: return "Active"
+            case .stopped: return "Stopped"
+            case .interrupted: return "Interrupted by system"
+            case .error: return "Error"
+            }
+        }
+    }
+
+    struct RouteOutputInfo: Identifiable, Hashable {
+        let id: String
+        let name: String
+        let portType: AVAudioSession.Port
+        let uid: String
+        let channels: Int
+    }
+
+    @Published private(set) var engineState: EngineState = .stopped
+    @Published private(set) var currentRouteSummary: String = "System Output"
+    @Published private(set) var routeOutputs: [RouteOutputInfo] = []
+    @Published private(set) var negotiatedSampleRate: Double = 0
+    @Published private(set) var negotiatedBufferFrames: Int = 0
+    @Published private(set) var negotiatedOutputChannels: Int = 0
+    @Published private(set) var lastRouteChangeReason: String = "Unknown"
+    @Published private(set) var lastRouteChangeTimestamp: Date? = nil
+    @Published private(set) var lastRouteChangeFailed: Bool = false
+    @Published var routeChangeBanner: String? = nil
+    @Published private(set) var availableInputs: [AVAudioSessionPortDescription] = []
+    @Published private(set) var selectedInputUID: String = UserDefaults.standard.string(
+        forKey: SettingsKeys.audioInputUID
+    ) ?? ""
+
+    @AppStorage(SettingsKeys.audioPreferredSampleRate)
+    private var storedPreferredSampleRate: Double = 48_000
+    @AppStorage(SettingsKeys.audioPreferredBufferFrames)
+    private var storedPreferredBufferFrames: Int = 256
+    @AppStorage(SettingsKeys.audioPreferSpeaker)
+    private var storedPreferSpeaker: Bool = false
+
+    private var routeObserver: NSObjectProtocol?
+    private var interruptionObserver: NSObjectProtocol?
+    private var isReinitializing: Bool = false
+    private let outputEngine = ToneOutputEngine.shared
+
+    private init() {
+        refreshAll()
+        observeSessionNotifications()
+    }
+
+    deinit {
+        if let routeObserver { NotificationCenter.default.removeObserver(routeObserver) }
+        if let interruptionObserver { NotificationCenter.default.removeObserver(interruptionObserver) }
+    }
+
+    var isEngineActive: Bool { engineState == .active }
+    var preferredSampleRate: Double { storedPreferredSampleRate }
+    var preferredBufferFrames: Int { storedPreferredBufferFrames }
+    var preferSpeaker: Bool { storedPreferSpeaker }
+    var supportsInput: Bool { AVAudioSession.sharedInstance().isInputAvailable }
+
+    func refreshAll() {
+        refreshRouteState()
+        refreshInputs()
+        refreshEngineState()
+    }
+
+    func refreshInputs() {
+        let session = AVAudioSession.sharedInstance()
+        var inputs = session.availableInputs ?? []
+        if inputs.isEmpty {
+            inputs = session.currentRoute.inputs
+        }
+        availableInputs = inputs
+
+        if !selectedInputUID.isEmpty,
+           inputs.contains(where: { $0.uid == selectedInputUID }) {
+            return
+        }
+
+        if let builtIn = inputs.first(where: { $0.portType == .builtInMic }) {
+            selectInput(builtIn)
+        } else if let first = inputs.first {
+            selectInput(first)
+        } else {
+            selectedInputUID = ""
+        }
+    }
+
+    func selectInput(_ input: AVAudioSessionPortDescription) {
+        selectedInputUID = input.uid
+        UserDefaults.standard.set(selectedInputUID, forKey: SettingsKeys.audioInputUID)
+    }
+
+    func applyPreferences(sampleRate: Double? = nil, bufferFrames: Int? = nil) {
+        if let sr = sampleRate {
+            storedPreferredSampleRate = sr
+        }
+        if let frames = bufferFrames {
+            storedPreferredBufferFrames = frames
+        }
+        applySessionPreferences()
+    }
+
+    func setPreferSpeaker(_ enabled: Bool) {
+        storedPreferSpeaker = enabled
+        applySpeakerOverride()
+    }
+
+    func reinitializeOutputRoute() {
+        guard !isReinitializing else { return }
+        isReinitializing = true
+
+        let snapshots = outputEngine.snapshotActiveVoices()
+        let fadeSeconds = snapshots.isEmpty ? 0.0 : 0.08
+        if fadeSeconds > 0 {
+            outputEngine.fadeOutAllVoices(releaseSeconds: fadeSeconds)
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + fadeSeconds) { [weak self] in
+            self?.performRouteReinitialize(with: snapshots)
+        }
+    }
+
+    func resumeEngineIfNeeded() {
+        guard engineState == .interrupted else { return }
+        reinitializeOutputRoute()
+    }
+
+    func diagnosticsText() -> String {
+        let session = AVAudioSession.sharedInstance()
+        let routeList = routeOutputs
+            .map { "• \($0.name) (\($0.portType.rawValue)) uid=\($0.uid)" }
+            .joined(separator: "\n")
+
+        let categoryOptions = session.categoryOptions
+        let options = [
+            categoryOptions.contains(.mixWithOthers) ? "mixWithOthers" : nil,
+            categoryOptions.contains(.allowBluetooth) ? "allowBluetooth" : nil,
+            categoryOptions.contains(.allowBluetoothA2DP) ? "allowBluetoothA2DP" : nil,
+            categoryOptions.contains(.allowAirPlay) ? "allowAirPlay" : nil,
+            categoryOptions.contains(.defaultToSpeaker) ? "defaultToSpeaker" : nil
+        ].compactMap { $0 }.joined(separator: ", ")
+
+        let bufferDuration = session.ioBufferDuration
+        let actualBufferFrames = Int(round(bufferDuration * session.sampleRate))
+        let preferredBuffer = storedPreferredBufferFrames
+        let preferredRate = storedPreferredSampleRate
+        let lastReason = lastRouteChangeReason
+        let lastTime = lastRouteChangeTimestamp?.description ?? "n/a"
+
+        return """
+        Route Outputs:
+        \(routeList.isEmpty ? "• none" : routeList)
+
+        Category: \(session.category.rawValue)
+        Mode: \(session.mode.rawValue)
+        Options: \(options.isEmpty ? "none" : options)
+        IO Buffer Duration: \(String(format: "%.4f", bufferDuration))s
+        Preferred SR: \(Int(preferredRate)) Hz
+        Actual SR: \(Int(session.sampleRate)) Hz
+        Preferred Buffer: \(preferredBuffer) frames
+        Actual Buffer: \(actualBufferFrames) frames
+        Last Route Change: \(lastReason) at \(lastTime)
+        """
+    }
+
+    func copyDiagnostics() {
+        let text = diagnosticsText()
+        #if canImport(UIKit)
+        UIPasteboard.general.string = text
+        #endif
+    }
+
+    private func observeSessionNotifications() {
+        routeObserver = NotificationCenter.default.addObserver(
+            forName: AVAudioSession.routeChangeNotification,
+            object: AVAudioSession.sharedInstance(),
+            queue: .main
+        ) { [weak self] notif in
+            self?.handleRouteChange(notification: notif)
+        }
+        interruptionObserver = NotificationCenter.default.addObserver(
+            forName: AVAudioSession.interruptionNotification,
+            object: AVAudioSession.sharedInstance(),
+            queue: .main
+        ) { [weak self] notif in
+            self?.handleInterruption(notification: notif)
+        }
+    }
+
+    private func performRouteReinitialize(with snapshots: [ToneOutputEngine.VoiceSnapshot]) {
+        let session = AVAudioSession.sharedInstance()
+        var didFail = false
+        outputEngine.hardStopEngine(deactivateSession: false)
+
+        do {
+            try session.setActive(false, options: [.notifyOthersOnDeactivation])
+        } catch {
+            didFail = true
+            lastRouteChangeFailed = true
+            #if DEBUG
+            print("[AudioSessionController] deactivate failed: \(error)")
+            #endif
+        }
+
+        applySessionPreferences()
+        didFail = didFail || lastRouteChangeFailed
+
+        if !snapshots.isEmpty {
+            for snap in snapshots {
+                _ = outputEngine.sustain(
+                    freq: snap.freq,
+                    amp: snap.amp,
+                    owner: snap.owner,
+                    ownerKey: snap.ownerKey,
+                    attackMs: nil,
+                    releaseMs: nil
+                )
+            }
+        }
+
+        refreshAll()
+        if !didFail {
+            lastRouteChangeFailed = false
+        }
+        isReinitializing = false
+    }
+
+    private func applySessionPreferences() {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            let sr = storedPreferredSampleRate
+            if sr > 0 {
+                try session.setPreferredSampleRate(sr)
+            }
+            let actualSR = session.sampleRate > 0 ? session.sampleRate : max(1.0, storedPreferredSampleRate)
+            let frames = max(32, storedPreferredBufferFrames)
+            let duration = Double(frames) / actualSR
+            try session.setPreferredIOBufferDuration(duration)
+            try session.setActive(true, options: [])
+        } catch {
+            lastRouteChangeFailed = true
+            #if DEBUG
+            print("[AudioSessionController] applySessionPreferences error: \(error)")
+            #endif
+        }
+        applySpeakerOverride()
+        refreshRouteState()
+    }
+
+    private func applySpeakerOverride() {
+        let session = AVAudioSession.sharedInstance()
+        let outputs = session.currentRoute.outputs
+        let isExternal = outputs.contains { port in
+            port.portType == .airPlay || port.portType == .bluetoothA2DP ||
+            port.portType == .bluetoothLE || port.portType == .bluetoothHFP ||
+            port.portType == .usbAudio
+        }
+
+        guard session.category == .playAndRecord else { return }
+
+        do {
+            if isExternal {
+                try session.overrideOutputAudioPort(.none)
+                return
+            }
+            if storedPreferSpeaker {
+                try session.overrideOutputAudioPort(.speaker)
+            } else {
+                try session.overrideOutputAudioPort(.none)
+            }
+        } catch {
+            #if DEBUG
+            print("[AudioSessionController] override speaker failed: \(error)")
+            #endif
+        }
+    }
+
+    private func refreshRouteState() {
+        let session = AVAudioSession.sharedInstance()
+        let outputs = session.currentRoute.outputs
+        routeOutputs = outputs.map { output in
+            RouteOutputInfo(
+                id: output.uid,
+                name: output.portName,
+                portType: output.portType,
+                uid: output.uid,
+                channels: output.channels.count
+            )
+        }
+        currentRouteSummary = routeSummary(for: outputs)
+        negotiatedSampleRate = session.sampleRate
+        negotiatedBufferFrames = Int(round(session.ioBufferDuration * session.sampleRate))
+        if outputs.isEmpty {
+            negotiatedOutputChannels = 0
+        } else {
+            negotiatedOutputChannels = max(1, outputs.reduce(0) { $0 + max(1, $1.channels.count) })
+        }
+    }
+
+    private func refreshEngineState() {
+        if outputEngine.isEngineRunning {
+            engineState = .active
+        } else {
+            engineState = .stopped
+        }
+    }
+
+    private func handleRouteChange(notification: Notification) {
+        let previous = currentRouteSummary
+        refreshRouteState()
+        refreshEngineState()
+
+        if let reasonValue = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt,
+           let reason = AVAudioSession.RouteChangeReason(rawValue: reasonValue) {
+            lastRouteChangeReason = routeChangeReasonText(reason)
+            lastRouteChangeTimestamp = Date()
+        } else {
+            lastRouteChangeReason = "Unknown"
+            lastRouteChangeTimestamp = Date()
+        }
+
+        let current = currentRouteSummary
+        if previous != current {
+            routeChangeBanner = "Route changed: \(previous) → \(current)"
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.4) { [weak self] in
+                if self?.routeChangeBanner == "Route changed: \(previous) → \(current)" {
+                    self?.routeChangeBanner = nil
+                }
+            }
+        }
+        lastRouteChangeFailed = false
+        #if DEBUG
+        print("[AudioSessionController] route changed: \(previous) -> \(current)")
+        #endif
+    }
+
+    private func handleInterruption(notification: Notification) {
+        guard let typeValue = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: typeValue) else {
+            return
+        }
+
+        switch type {
+        case .began:
+            engineState = .interrupted
+        case .ended:
+            refreshEngineState()
+        @unknown default:
+            break
+        }
+    }
+
+    private func routeSummary(for outputs: [AVAudioSessionPortDescription]) -> String {
+        guard let first = outputs.first else { return "System Output" }
+
+        let name = first.portName
+        switch first.portType {
+        case .usbAudio:
+            return "USB Audio — \(name)"
+        case .airPlay:
+            return "AirPlay — \(name)"
+        case .bluetoothA2DP, .bluetoothLE, .bluetoothHFP:
+            return "Bluetooth — \(name)"
+        case .headphones, .headsetMic:
+            return "Headphones"
+        case .builtInSpeaker:
+            return "Built-in Speaker"
+        default:
+            return name.isEmpty ? "System Output" : name
+        }
+    }
+
+    private func routeChangeReasonText(_ reason: AVAudioSession.RouteChangeReason) -> String {
+        switch reason {
+        case .newDeviceAvailable: return "New device available"
+        case .oldDeviceUnavailable: return "Device disconnected"
+        case .categoryChange: return "Category changed"
+        case .override: return "Output override"
+        case .wakeFromSleep: return "Wake from sleep"
+        case .noSuitableRouteForCategory: return "No suitable route"
+        case .routeConfigurationChange: return "Route configuration change"
+        case .unknown: return "Unknown"
+        @unknown default: return "Unknown"
+        }
+    }
+}

--- a/Tenney/ProAudioSettingsView.swift
+++ b/Tenney/ProAudioSettingsView.swift
@@ -2,41 +2,27 @@
 //  ProAudioSettingsView.swift
 //  Tenney
 //
-//  Revamped to match Settings cards (iOS 26 glass), show real input devices,
-//  and use the same tile language as Theme/A4 pickers.
+//  Pro Audio Settings View vNext
 //
-import Foundation
-import SwiftUI
-import AVFAudio
+import AVFoundation
 import AVKit
-import UIKit
+import SwiftUI
 
 public struct ProAudioSettingsView: View {
-    
+
     // Whether to draw its own rounded-rect card background and title.
-        // When false, we render "flat" so the parent can supply the material layer.
-        private let showsOuterCard: Bool
-    
-    // MARK: - Persisted prefs (use existing keys where present)
-    @AppStorage(SettingsKeys.audioPreferredSampleRate) private var preferredSampleRate: Double = 48_000
-    @AppStorage(SettingsKeys.audioPreferredBufferFrames) private var preferredBufferFrames: Int = 256
+    // When false, we render "flat" so the parent can supply the material layer.
+    private let showsOuterCard: Bool
 
-    // Not introducing a new SettingsKeys key for channel mode to avoid compile churn
-    @State private var preferredChannelMode: Int = 1  // 0-Mono, 1-Stereo, 2-Multi
+    @StateObject private var controller = AudioSessionController.shared
+    @State private var preferredChannelMode: ChannelMode = .stereo
     @State private var monitorInput: Bool = false
-    @AppStorage(SettingsKeys.audioPreferSpeaker) private var preferSpeaker: Bool = false
+    @State private var micPermission: MicrophonePermission.Status = .undetermined
+    @State private var advancedExpanded: Bool = false
+    @State private var diagnosticsExpanded: Bool = false
 
-    // Input devices
-    @State private var availableInputs: [AVAudioSessionPortDescription] = []
-    @State private var selectedInputUID: String = ""
-    @State private var selectedInputName: String = ""
-    @Namespace private var inputNS
-    @State private var currentOutputs: [AVAudioSessionPortDescription] = []
-    @State private var routeObserver: NSObjectProtocol?
-
-    // Grids aligned with Theme/A4 cards
     private let deviceCols = [GridItem(.adaptive(minimum: 150, maximum: 220), spacing: 12, alignment: .top)]
-    private let optCols    = [GridItem(.adaptive(minimum: 110, maximum: 160), spacing: 12, alignment: .top)]
+    private let optCols = [GridItem(.adaptive(minimum: 110, maximum: 160), spacing: 12, alignment: .top)]
 
     public init(showsOuterCard: Bool = true) {
         self.showsOuterCard = showsOuterCard
@@ -45,7 +31,7 @@ public struct ProAudioSettingsView: View {
     public var body: some View {
         Group {
             if showsOuterCard {
-                card("Pro Audio · Input & Engine") {
+                outerCard("Pro Audio") {
                     coreContent
                 }
             } else {
@@ -53,120 +39,453 @@ public struct ProAudioSettingsView: View {
             }
         }
         .onAppear {
-            refreshInputs()
-            refreshOutputs()
-            applySpeakerOverride()
-            // Listen for system route changes so our chips reflect user selection
-            routeObserver = NotificationCenter.default.addObserver(
-                forName: AVAudioSession.routeChangeNotification,
-                object: AVAudioSession.sharedInstance(),
-                queue: .main
-            ) { _ in
-                refreshOutputs()
-            }
-        }
-        .onDisappear {
-            if let obs = routeObserver {
-                NotificationCenter.default.removeObserver(obs)
-                routeObserver = nil
-            }
+            controller.refreshAll()
+            micPermission = MicrophonePermission.status()
         }
     }
 
     @ViewBuilder
     private var coreContent: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            // == Input devices ==
-            headerRow(title: "Input Device", icon: "waveform.badge.mic")
-            LazyVGrid(columns: deviceCols, spacing: 12) {
-                ForEach(availableInputs, id: \.uid) { input in
-                    let sel = (selectedInputUID == input.uid)
-                    DeviceCard(
-                        title: displayName(for: input),
-                        subtitle: subtitle(for: input),
-                        symbol: symbolName(for: input),
-                        selected: sel
-                    ) { select(input) }
-                    .matchedGeometryEffect(id: sel ? "selectedDevice" : "\(input.uid)-idle", in: inputNS, isSource: true)
-                    .accessibilityElement(children: .combine)
-                    .accessibilityLabel(displayName(for: input))
-                    .accessibilityAddTraits(sel ? .isSelected : [])
-                }
+        VStack(alignment: .leading, spacing: 16) {
+            routingCard
+            engineCard
+            if controller.supportsInput || micPermission != .granted {
+                inputMonitoringCard
             }
-            if availableInputs.isEmpty {
-                EmptyDevicesFallback()
-            }
-
-            // == Channel mode ==
-            headerRow(title: "Channel Mode", icon: "square.3.layers.3d.down.right")
-            LazyVGrid(columns: optCols, spacing: 12) {
-                OptionTile(label: "Mono", selected: preferredChannelMode == 0) {
-                    withAnimation(.snappy) { preferredChannelMode = 0 }
-                }
-                OptionTile(label: "Stereo", selected: preferredChannelMode == 1) {
-                    withAnimation(.snappy) { preferredChannelMode = 1 }
-                }
-                OptionTile(label: "Multi-Channel", selected: preferredChannelMode == 2) {
-                    withAnimation(.snappy) { preferredChannelMode = 2 }
-                }
-            }
-
-            // == Sample rate ==
-            headerRow(title: "Sample Rate", icon: "metronome.fill")
-            LazyVGrid(columns: optCols, spacing: 12) {
-                RateTile(label: "44.1 kHz", rate: 44_100, current: preferredSampleRate) { commitSampleRate(44_100) }
-                RateTile(label: "48 kHz",   rate: 48_000, current: preferredSampleRate) { commitSampleRate(48_000) }
-                RateTile(label: "96 kHz",   rate: 96_000, current: preferredSampleRate) { commitSampleRate(96_000) }
-            }
-
-            // == Buffer size ==
-            headerRow(title: "Buffer Size (frames)", icon: "memorychip.fill")
-            LazyVGrid(columns: optCols, spacing: 12) {
-                BufferTile(size: 128,  current: preferredBufferFrames) { commitBuffer(128) }
-                BufferTile(size: 256,  current: preferredBufferFrames) { commitBuffer(256) }
-                BufferTile(size: 512,  current: preferredBufferFrames) { commitBuffer(512) }
-                BufferTile(size: 1024, current: preferredBufferFrames) { commitBuffer(1024) }
-            }
-
-            // == Monitor ==
-            Toggle("Monitor Input", isOn: $monitorInput)
-                .onChange(of: monitorInput) { _ in manageInputMonitoring() }
-            if monitorInput {
-                Text("Make sure outputs are isolated to avoid feedback.")
-                    .font(.footnote).foregroundStyle(.secondary)
-            }
-
-            // == Output & routing ==
-            Divider().padding(.vertical, 2)
-            headerRow(title: "Output & Routing", icon: "speaker.wave.2.fill")
-
-            // System route picker (this is how iOS exposes the device list)
-            RoutePickerRow()
-
-            // Current route badges (update on change)
-            CurrentRouteRow(outputs: currentOutputs.map { (outputDisplayName(for: $0), outputSymbolName(for: $0)) })
-
-            // Optional: Prefer Speaker (the only programmatic override iOS allows)
-            Toggle("Prefer Speaker (when possible)", isOn: $preferSpeaker)
-                .onChange(of: preferSpeaker) { _ in applySpeakerOverride() }
-
-            Text("Use the button above to choose Bluetooth, AirPlay, USB, etc. “Prefer Speaker” only works in certain categories (e.g., Play & Record).")
-                .font(.footnote)
-                .foregroundStyle(.secondary)
+            diagnosticsCard
         }
     }
 
-    
-    private func refreshOutputs() {
-            let session = AVAudioSession.sharedInstance()
-            currentOutputs = session.currentRoute.outputs
-        }
+    // MARK: - Routing
 
-    // MARK: - Cards (match StudioConsoleView glass language; no extra horizontal padding)
+    private var routingCard: some View {
+        card(prominent: true) {
+            VStack(alignment: .leading, spacing: 12) {
+                headerRow(title: "Routing", icon: "hifispeaker.2")
+
+                if let banner = controller.routeChangeBanner {
+                    Text(banner)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(.ultraThinMaterial, in: Capsule())
+                        .overlay(Capsule().stroke(Color.secondary.opacity(0.12), lineWidth: 1))
+                        .transition(.opacity)
+                }
+
+                OutputPickerRow(
+                    icon: outputIcon(for: controller.routeOutputs.first?.portType),
+                    summary: controller.currentRouteSummary
+                )
+
+                RouteInspectorChips(chips: routeInspectorChips)
+
+                if shouldShowReinitializeButton {
+                    ReinitializeRouteButton {
+                        controller.reinitializeOutputRoute()
+                    }
+                }
+
+                Toggle("Force Built-in Speaker (when allowed)", isOn: Binding(
+                    get: { controller.preferSpeaker },
+                    set: { controller.setPreferSpeaker($0) }
+                ))
+                .toggleStyle(.switch)
+
+                Text("Only applies in Play & Record; ignored for USB/AirPlay.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            .animation(.easeOut(duration: 0.18), value: controller.routeChangeBanner)
+        }
+    }
+
+    private var routeInspectorChips: [RouteChip] {
+        let outputs = controller.routeOutputs
+        let portType = outputs.first?.portType
+        let deviceName = outputs.first?.name ?? "System Output"
+        let portLabel = portTypeLabel(portType)
+        let latency = latencyLabel(for: portType)
+        let channels = controller.negotiatedOutputChannels
+        let rate = Int(controller.negotiatedSampleRate.rounded())
+        let buffer = controller.negotiatedBufferFrames
+        let rateBufferLabel = rate > 0 && buffer > 0 ? "\(rate / 1000)k · \(buffer)f" : "--"
+
+        return [
+            RouteChip(label: deviceName, systemImage: "headphones"),
+            RouteChip(label: portLabel, systemImage: "cable.connector"),
+            RouteChip(label: latency, systemImage: "speedometer"),
+            RouteChip(label: "\(channels)ch", systemImage: "circle.grid.3x3"),
+            RouteChip(label: rateBufferLabel, systemImage: "waveform.path.ecg")
+        ]
+    }
+
+    private var shouldShowReinitializeButton: Bool {
+        let outputs = controller.routeOutputs
+        let isWireless = outputs.contains {
+            $0.portType == .airPlay || $0.portType == .bluetoothA2DP || $0.portType == .bluetoothLE || $0.portType == .bluetoothHFP
+        }
+        return (isWireless && controller.isEngineActive) || controller.lastRouteChangeFailed
+    }
+
+    // MARK: - Engine
+
+    private var engineCard: some View {
+        card {
+            VStack(alignment: .leading, spacing: 12) {
+                headerRow(title: "Engine", icon: "waveform.path.ecg")
+
+                EngineStatusCapsule(
+                    state: controller.engineState,
+                    rate: controller.negotiatedSampleRate,
+                    bufferFrames: controller.negotiatedBufferFrames,
+                    channels: controller.negotiatedOutputChannels,
+                    onResume: controller.engineState == .interrupted ? {
+                        controller.resumeEngineIfNeeded()
+                    } : nil
+                )
+
+                performancePresets
+
+                DisclosureGroup(isExpanded: $advancedExpanded) {
+                    VStack(alignment: .leading, spacing: 12) {
+                        sampleRateOverrides
+                        bufferOverrides
+                        channelModeOverrides
+                    }
+                    .padding(.top, 6)
+                } label: {
+                    Text("Advanced")
+                        .font(.subheadline.weight(.semibold))
+                }
+            }
+        }
+    }
+
+    private var performancePresets: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Performance Presets")
+                .font(.subheadline.weight(.semibold))
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 140, maximum: 200), spacing: 12)], spacing: 12) {
+                PresetTile(
+                    title: "Low Latency",
+                    subtitle: "48k · 128–256f",
+                    selected: isPresetSelected(sampleRate: 48_000, buffer: 128)
+                ) {
+                    applyPreset(sampleRate: 48_000, bufferFrames: 128)
+                }
+
+                PresetTile(
+                    title: "Stable",
+                    subtitle: "48k · 256–512f",
+                    selected: isPresetSelected(sampleRate: 48_000, buffer: 256)
+                ) {
+                    applyPreset(sampleRate: 48_000, bufferFrames: 256)
+                }
+
+                PresetTile(
+                    title: "High Quality",
+                    subtitle: "96k · 512f+",
+                    selected: isPresetSelected(sampleRate: 96_000, buffer: 512)
+                ) {
+                    applyPreset(sampleRate: 96_000, bufferFrames: 512)
+                }
+            }
+        }
+    }
+
+    private var sampleRateOverrides: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Sample Rate")
+                .font(.subheadline.weight(.semibold))
+
+            LazyVGrid(columns: optCols, spacing: 12) {
+                RateTile(label: "44.1 kHz", rate: 44_100, current: controller.preferredSampleRate) {
+                    controller.applyPreferences(sampleRate: 44_100)
+                }
+                RateTile(label: "48 kHz", rate: 48_000, current: controller.preferredSampleRate) {
+                    controller.applyPreferences(sampleRate: 48_000)
+                }
+                RateTile(label: "96 kHz", rate: 96_000, current: controller.preferredSampleRate) {
+                    controller.applyPreferences(sampleRate: 96_000)
+                }
+            }
+
+            if let badge = sampleRateBadgeText {
+                BadgeText(text: badge)
+            }
+        }
+    }
+
+    private var bufferOverrides: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Buffer Size (frames)")
+                .font(.subheadline.weight(.semibold))
+
+            LazyVGrid(columns: optCols, spacing: 12) {
+                BufferTile(size: 128, current: controller.preferredBufferFrames) { controller.applyPreferences(bufferFrames: 128) }
+                BufferTile(size: 256, current: controller.preferredBufferFrames) { controller.applyPreferences(bufferFrames: 256) }
+                BufferTile(size: 512, current: controller.preferredBufferFrames) { controller.applyPreferences(bufferFrames: 512) }
+                BufferTile(size: 1024, current: controller.preferredBufferFrames) { controller.applyPreferences(bufferFrames: 1024) }
+            }
+
+            if let badge = bufferBadgeText {
+                BadgeText(text: badge)
+            }
+        }
+    }
+
+    private var channelModeOverrides: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Channel Mode")
+                .font(.subheadline.weight(.semibold))
+
+            LazyVGrid(columns: optCols, spacing: 12) {
+                ChannelModeTile(label: "Mono", selected: preferredChannelMode == .mono) {
+                    preferredChannelMode = .mono
+                }
+                ChannelModeTile(label: "Stereo", selected: preferredChannelMode == .stereo) {
+                    preferredChannelMode = .stereo
+                }
+                ChannelModeTile(
+                    label: "Multi",
+                    selected: preferredChannelMode == .multi,
+                    disabled: !supportsMultiChannel
+                ) {
+                    preferredChannelMode = .multi
+                }
+            }
+
+            if !supportsMultiChannel {
+                BadgeText(text: "Route supports up to 2 channels")
+            }
+        }
+    }
+
+    // MARK: - Input + Monitoring
+
+    private var inputMonitoringCard: some View {
+        card {
+            VStack(alignment: .leading, spacing: 12) {
+                headerRow(title: "Input + Monitoring", icon: "waveform.badge.mic")
+
+                if micPermission != .granted {
+                    MicrophonePermissionCTA(status: micPermission) {
+                        handleMicPermissionRequest()
+                    }
+                }
+
+                if micPermission == .granted {
+                    LazyVGrid(columns: deviceCols, spacing: 12) {
+                        ForEach(controller.availableInputs, id: \.uid) { input in
+                            DeviceTile(
+                                title: displayName(for: input),
+                                subtitle: subtitle(for: input),
+                                symbol: symbolName(for: input),
+                                selected: controller.selectedInputUID == input.uid
+                            ) {
+                                controller.selectInput(input)
+                            }
+                        }
+                    }
+                    if controller.availableInputs.isEmpty {
+                        EmptyDevicesFallback()
+                    }
+                }
+
+                Toggle("Input Monitoring", isOn: $monitorInput)
+                if monitorInput {
+                    Text("Make sure outputs are isolated to avoid feedback.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Diagnostics
+
+    private var diagnosticsCard: some View {
+        card {
+            VStack(alignment: .leading, spacing: 12) {
+                DisclosureGroup(isExpanded: $diagnosticsExpanded) {
+                    VStack(alignment: .leading, spacing: 10) {
+                        DiagnosticsSection(outputs: controller.routeOutputs)
+                        diagnosticsSessionDetails
+
+                        Button {
+                            controller.copyDiagnostics()
+                        } label: {
+                            Label("Copy Diagnostics", systemImage: "doc.on.doc")
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                    .padding(.top, 6)
+                } label: {
+                    Text("Diagnostics")
+                        .font(.subheadline.weight(.semibold))
+                }
+            }
+        }
+    }
+
+    private var diagnosticsSessionDetails: some View {
+        let session = AVAudioSession.sharedInstance()
+        let lastRouteTime = controller.lastRouteChangeTimestamp?.formatted(date: .numeric, time: .standard) ?? "n/a"
+
+        return VStack(alignment: .leading, spacing: 6) {
+            DiagnosticsRow(label: "Category", value: session.category.rawValue)
+            DiagnosticsRow(label: "Mode", value: session.mode.rawValue)
+            DiagnosticsRow(label: "Options", value: session.categoryOptions.prettyList)
+            DiagnosticsRow(label: "IO Buffer Duration", value: String(format: "%.4fs", session.ioBufferDuration))
+            DiagnosticsRow(label: "Preferred SR", value: "\(Int(controller.preferredSampleRate)) Hz")
+            DiagnosticsRow(label: "Actual SR", value: "\(Int(controller.negotiatedSampleRate)) Hz")
+            DiagnosticsRow(label: "Preferred Buffer", value: "\(controller.preferredBufferFrames) f")
+            DiagnosticsRow(label: "Actual Buffer", value: "\(controller.negotiatedBufferFrames) f")
+            DiagnosticsRow(label: "Last Route Change", value: "\(controller.lastRouteChangeReason) · \(lastRouteTime)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var supportsMultiChannel: Bool {
+        controller.negotiatedOutputChannels > 2
+    }
+
+    private func applyPreset(sampleRate: Double, bufferFrames: Int) {
+        controller.applyPreferences(sampleRate: sampleRate, bufferFrames: bufferFrames)
+    }
+
+    private func isPresetSelected(sampleRate: Double, buffer: Int) -> Bool {
+        controller.preferredSampleRate == sampleRate && controller.preferredBufferFrames == buffer
+    }
+
+    private var sampleRateBadgeText: String? {
+        let actual = Int(controller.negotiatedSampleRate.rounded())
+        let preferred = Int(controller.preferredSampleRate.rounded())
+        guard actual > 0, preferred > 0, actual != preferred else { return nil }
+
+        if controller.routeOutputs.first?.portType == .usbAudio {
+            return "USB device locked at \(actual / 1000)k"
+        }
+        return "System locked at \(actual / 1000)k"
+    }
+
+    private var bufferBadgeText: String? {
+        let actual = controller.negotiatedBufferFrames
+        let preferred = controller.preferredBufferFrames
+        guard actual > 0, actual != preferred else { return nil }
+
+        if let port = controller.routeOutputs.first?.portType,
+           port == .airPlay || port == .bluetoothA2DP || port == .bluetoothLE || port == .bluetoothHFP {
+            return "AirPlay/Bluetooth forces high latency"
+        }
+        return "System forced buffer to \(actual)f"
+    }
+
+    private func handleMicPermissionRequest() {
+        switch micPermission {
+        case .undetermined:
+            MicrophonePermission.ensure { granted in
+                micPermission = granted ? .granted : .denied
+                if granted {
+                    controller.refreshInputs()
+                }
+            }
+        case .denied:
+            MicrophonePermission.openAppSettings()
+        case .granted:
+            break
+        }
+    }
+
+    private func outputIcon(for portType: AVAudioSession.Port?) -> String {
+        switch portType {
+        case .builtInSpeaker: return "speaker.wave.2.fill"
+        case .headphones, .headsetMic: return "headphones"
+        case .bluetoothA2DP, .bluetoothLE, .bluetoothHFP: return "wave.3.right.circle.fill"
+        case .airPlay: return "airplayaudio"
+        case .usbAudio: return "memorychip"
+        default: return "speaker.wave.2"
+        }
+    }
+
+    private func portTypeLabel(_ portType: AVAudioSession.Port?) -> String {
+        switch portType {
+        case .usbAudio: return "USB"
+        case .airPlay: return "AirPlay"
+        case .bluetoothA2DP, .bluetoothLE, .bluetoothHFP: return "Bluetooth"
+        case .headphones, .headsetMic: return "Headphones"
+        case .builtInSpeaker: return "Speaker"
+        default: return "System"
+        }
+    }
+
+    private func latencyLabel(for portType: AVAudioSession.Port?) -> String {
+        switch portType {
+        case .airPlay, .bluetoothA2DP, .bluetoothLE, .bluetoothHFP:
+            return "High Latency"
+        case .usbAudio, .headphones, .headsetMic, .builtInSpeaker:
+            return "Low Latency"
+        default:
+            return "Medium Latency"
+        }
+    }
+
+    private func displayName(for input: AVAudioSessionPortDescription) -> String {
+        if input.portType == .builtInMic { return "Built-in Microphone" }
+        return input.portName
+    }
+
+    private func subtitle(for input: AVAudioSessionPortDescription) -> String {
+        switch input.portType {
+        case .builtInMic: return "On-device"
+        case .headsetMic: return "Headset"
+        case .bluetoothHFP, .bluetoothLE, .bluetoothA2DP: return "Bluetooth"
+        case .lineIn: return "Line-In"
+        case .usbAudio: return "USB Audio"
+        default: return input.portType.rawValue
+        }
+    }
+
+    private func symbolName(for input: AVAudioSessionPortDescription) -> String {
+        switch input.portType {
+        case .builtInMic: return "mic.fill"
+        case .headsetMic: return "headphones"
+        case .bluetoothHFP, .bluetoothLE, .bluetoothA2DP: return "wave.3.right.circle.fill"
+        case .lineIn: return "cable.connector"
+        case .usbAudio: return "memorychip"
+        default: return "mic"
+        }
+    }
+
     @ViewBuilder
-    private func card<Content: View>(_ title: String, @ViewBuilder _ content: () -> Content) -> some View {
+    private func card<Content: View>(prominent: Bool = false, @ViewBuilder _ content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text(title).font(.headline)
+            content()
+        }
+        .padding(prominent ? 16 : 14)
+        .background(
+            Group {
+                if #available(iOS 26.0, *) {
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .fill(.clear)
+                        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                } else {
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .fill(prominent ? .regularMaterial : .ultraThinMaterial)
+                }
+            }
+        )
+    }
+
+    @ViewBuilder
+    private func outerCard<Content: View>(_ title: String, @ViewBuilder _ content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
             content()
         }
         .padding(14)
@@ -184,208 +503,114 @@ public struct ProAudioSettingsView: View {
         )
     }
 
-    // MARK: - Header row
     private func headerRow(title: String, icon: String) -> some View {
         HStack(spacing: 10) {
             Image(systemName: icon)
                 .symbolRenderingMode(.palette)
                 .foregroundStyle(
-                        .linearGradient(
-                            colors: [.red, .orange],
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
+                    .linearGradient(
+                        colors: [.red, .orange],
+                        startPoint: .leading,
+                        endPoint: .trailing
                     )
-
+                )
                 .imageScale(.large)
-                .symbolEffect(.bounce, value: title)
             Text(title).font(.subheadline.weight(.semibold))
         }
         .padding(.horizontal, 2)
     }
-
-    // MARK: - Device selection
-    private func refreshInputs() {
-        let session = AVAudioSession.sharedInstance()
-        var inputs = session.availableInputs ?? []
-        // Fallback: current route’s inputs (e.g., when microphones are restricted)
-        if inputs.isEmpty {
-            inputs = session.currentRoute.inputs
-        }
-        availableInputs = inputs
-
-        // Choose a sensible default
-        if !availableInputs.contains(where: { $0.uid == selectedInputUID }) {
-            if let builtIn = availableInputs.first(where: { $0.portType == .builtInMic }) {
-                select(builtIn)
-            } else if let first = availableInputs.first {
-                select(first)
-            } else {
-                selectedInputUID = ""
-                selectedInputName = ""
-            }
-        }
-    }
-
-    private func select(_ input: AVAudioSessionPortDescription) {
-        withAnimation(.snappy) {
-            selectedInputUID = input.uid
-            selectedInputName = displayName(for: input)
-        }
-        // Persist lightweight identity; engine may apply this later.
-        UserDefaults.standard.set(selectedInputUID, forKey: SettingsKeys.audioInputUID)
-    }
-
-    private func displayName(for input: AVAudioSessionPortDescription) -> String {
-        if input.portType == .builtInMic { return "Built-in Microphone" }
-        return input.portName
-    }
-    private func subtitle(for input: AVAudioSessionPortDescription) -> String {
-        switch input.portType {
-        case .builtInMic:        return "On-device"
-        case .headsetMic:        return "Headset"
-        case .bluetoothHFP, .bluetoothLE, .bluetoothA2DP: return "Bluetooth"
-        case .lineIn:            return "Line-In"
-        case .usbAudio:          return "USB Audio"
-        default:                 return input.portType.rawValue
-        }
-    }
-    private func symbolName(for input: AVAudioSessionPortDescription) -> String {
-        switch input.portType {
-        case .builtInMic:        return "mic.fill"
-        case .headsetMic:        return "headphones"
-        case .bluetoothHFP, .bluetoothLE, .bluetoothA2DP: return "wave.3.right.circle.fill"
-        case .lineIn:            return "cable.connector"
-        case .usbAudio:          return "memorychip"
-        default:                 return "mic"
-        }
-    }
-
-    // MARK: - Commit prefs
-    private func commitSampleRate(_ hz: Double) {
-        let supported: Set<Double> = [44_100, 48_000, 96_000]
-        preferredSampleRate = supported.contains(hz) ? hz : 48_000
-    }
-    private func commitBuffer(_ frames: Int) {
-        let supported: Set<Int> = [128, 256, 512, 1024]
-        preferredBufferFrames = supported.contains(frames) ? frames : 256
-    }
-
-    private func manageInputMonitoring() {
-        // Hook for your engine to guard against feedback, etc.
-    }
-    private func applySpeakerOverride() {
-            let session = AVAudioSession.sharedInstance()
-            do {
-                try session.setActive(true, options: []) // harmless if already active
-                if preferSpeaker {
-                    try session.overrideOutputAudioPort(.speaker)
-                } else {
-                    try session.overrideOutputAudioPort(.none)
-                }
-            } catch {
-                // Non-fatal: iOS may ignore this based on category/route/security.
-            }
-            refreshOutputs()
-        }
 }
 
-
-    
-// MARK: - Subviews (match Theme/A4 card visual language)
-private struct DeviceCard: View {
-    let title: String
-    let subtitle: String
-    let symbol: String
-    let selected: Bool
-    let tap: () -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            ZStack(alignment: .topTrailing) {
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(.ultraThinMaterial)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 16, style: .continuous)
-                            .stroke(selected ? Color.accentColor.opacity(0.85)
-                                             : Color.secondary.opacity(0.15),
-                                    lineWidth: selected ? 2 : 1)
-                    )
-                    .frame(height: 64)
-                    .overlay(
-                        Image(systemName: symbol)
-                            .symbolRenderingMode(.palette)
-                            .foregroundStyle(.primary, .secondary)
-                            .font(.system(size: 22, weight: .semibold))
-                    )
-                if selected {
-                    Image(systemName: "checkmark.circle.fill")
-                        .symbolRenderingMode(.palette)
-                        .foregroundStyle(Color.accentColor, .white)
-                        .padding(8)
-                        .transition(.scale.combined(with: .opacity))
-                        .symbolEffect(.bounce, value: selected)
-                }
-            }
-            Text(title).font(.subheadline).lineLimit(1)
-            Text(subtitle).font(.caption).foregroundStyle(.secondary).lineLimit(1)
-        }
-        .padding(10)
-        .contentShape(Rectangle())
-        .onTapGesture(perform: tap)
-        .buttonStyle(.plain)
-    }
+private enum ChannelMode: Int {
+    case mono = 0
+    case stereo = 1
+    case multi = 2
 }
 
-private struct OptionTile: View {
-    let label: String
-    let selected: Bool
-    let tap: () -> Void
+// MARK: - Subviews
+
+private struct OutputPickerRow: View {
+    let icon: String
+    let summary: String
+
     var body: some View {
-        ZStack(alignment: .topTrailing) {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .symbolRenderingMode(.palette)
+                .foregroundStyle(.primary, .secondary)
+                .font(.system(size: 24, weight: .semibold))
+                .frame(width: 36)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Output")
+                    .font(.headline.weight(.semibold))
+                Text("Now routing to: \(summary)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            Spacer()
+
+            RoutePickerButton()
+                .frame(width: 52, height: 52)
+                .accessibilityLabel("Output route picker")
+        }
+        .padding(12)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.secondary.opacity(0.15), lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct RoutePickerButton: View {
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
                 .fill(.ultraThinMaterial)
                 .overlay(
-                    RoundedRectangle(cornerRadius: 16, style: .continuous)
-                        .stroke(selected ? Color.accentColor.opacity(0.85)
-                                         : Color.secondary.opacity(0.15),
-                                lineWidth: selected ? 2 : 1)
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
                 )
-                .frame(height: 64)
-                .overlay(
-                    Text(label)
-                        .font(.subheadline.weight(.semibold))
-                )
-            if selected {
-                Image(systemName: "checkmark.circle.fill")
-                    .symbolRenderingMode(.palette)
-                    .foregroundStyle(Color.accentColor, .white)
-                    .padding(8)
-                    .transition(.scale.combined(with: .opacity))
-                    .symbolEffect(.bounce, value: selected)
-            }
+            RoutePickerRepresentable()
+                .frame(width: 44, height: 44)
         }
-        .padding(10)
-        .contentShape(Rectangle())
-        .onTapGesture(perform: tap)
-        .buttonStyle(.plain)
     }
 }
 
-// MARK: - Current route badges
-private struct CurrentRouteRow: View {
-    let outputs: [(String, String)]  // (name, symbol)
+private struct RoutePickerRepresentable: UIViewRepresentable {
+    func makeUIView(context: Context) -> AVRoutePickerView {
+        let view = AVRoutePickerView()
+        view.prioritizesVideoDevices = false
+        view.tintColor = UIColor.label
+        view.activeTintColor = UIColor.systemBlue
+        return view
+    }
+
+    func updateUIView(_ uiView: AVRoutePickerView, context: Context) {}
+}
+
+private struct RouteInspectorChips: View {
+    let chips: [RouteChip]
+
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
-                ForEach(Array(outputs.enumerated()), id: \.offset) { _, item in
+                ForEach(chips) { chip in
                     HStack(spacing: 6) {
-                        Image(systemName: item.1).imageScale(.small)
-                        Text(item.0).font(.caption.weight(.semibold))
+                        Image(systemName: chip.systemImage)
+                            .imageScale(.small)
+                        Text(chip.label)
+                            .font(.caption.weight(.semibold))
                     }
-                    .padding(.horizontal, 10).padding(.vertical, 6)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
                     .background(.ultraThinMaterial, in: Capsule())
                     .overlay(Capsule().stroke(Color.secondary.opacity(0.12), lineWidth: 1))
+                    .accessibilityLabel(chip.label)
                 }
             }
             .padding(.vertical, 2)
@@ -393,65 +618,104 @@ private struct CurrentRouteRow: View {
     }
 }
 
-// MARK: - Prominent, visible route picker row
-private struct RoutePickerRow: View {
+private struct RouteChip: Identifiable {
+    let id = UUID()
+    let label: String
+    let systemImage: String
+}
+
+private struct ReinitializeRouteButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Reinitialize Output")
+                    .font(.subheadline.weight(.semibold))
+                Text("Fixes flaky AirPlay/Bluetooth routes without restarting the app.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct EngineStatusCapsule: View {
+    let state: AudioSessionController.EngineState
+    let rate: Double
+    let bufferFrames: Int
+    let channels: Int
+    let onResume: (() -> Void)?
+
     var body: some View {
         HStack(spacing: 12) {
-            Image(systemName: "airplayaudio")
-                .symbolRenderingMode(.palette)
-                .foregroundStyle(.primary, .secondary)
-                .imageScale(.large)
             VStack(alignment: .leading, spacing: 2) {
-                Text("Select Output").font(.subheadline.weight(.semibold))
-                Text("AirPlay • Bluetooth • USB").font(.caption).foregroundStyle(.secondary)
-            }
-            Spacer()
-            RoutePickerRepresentable()
-                .frame(width: 44, height: 44)   // show the native AirPlay button clearly
-        }
-        .padding(10)
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .stroke(Color.secondary.opacity(0.15), lineWidth: 1)
-        )
-    }
-}
+                Text("Engine: \(state.label)")
+                    .font(.subheadline.weight(.semibold))
 
-private struct RoutePickerRepresentable: UIViewRepresentable {
-    func makeUIView(context: Context) -> AVRoutePickerView {
-        let v = AVRoutePickerView()
-        v.prioritizesVideoDevices = false
-        v.tintColor = UIColor.label
-                if #available(iOS 13.0, *) {
-                    v.activeTintColor = UIColor.systemBlue
+                if state == .active {
+                    Text("\(Int(rate)) Hz · \(bufferFrames)f · \(channels)ch")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else if state == .interrupted {
+                    Text("Interrupted by system")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
-        return v
+            }
+
+            Spacer()
+
+            if let onResume, state == .interrupted {
+                Button("Resume", action: onResume)
+                    .buttonStyle(.bordered)
+            }
+        }
+        .padding(12)
+        .background(.ultraThinMaterial, in: Capsule())
+        .overlay(Capsule().stroke(Color.secondary.opacity(0.15), lineWidth: 1))
     }
-    func updateUIView(_ uiView: AVRoutePickerView, context: Context) {}
 }
 
-// MARK: - Output labels/icons
-private func outputDisplayName(for port: AVAudioSessionPortDescription) -> String {
-    switch port.portType {
-    case .builtInSpeaker: return "Built-in Speaker"
-    case .headphones:     return "Headphones"
-    case .bluetoothA2DP, .bluetoothLE, .bluetoothHFP: return "Bluetooth"
-    case .airPlay:        return "AirPlay"
-    case .lineOut:        return "Line Out"
-    case .usbAudio:       return "USB Audio"
-    default:              return port.portName
-    }
-}
-private func outputSymbolName(for port: AVAudioSessionPortDescription) -> String {
-    switch port.portType {
-    case .builtInSpeaker: return "speaker.wave.2.fill"
-    case .headphones:     return "headphones"
-    case .bluetoothA2DP, .bluetoothLE, .bluetoothHFP: return "wave.3.right.circle.fill"
-    case .airPlay:        return "airplayaudio"
-    case .lineOut:        return "cable.connector"
-    case .usbAudio:       return "memorychip"
-    default:              return "speaker.wave.2"
+private struct PresetTile: View {
+    let title: String
+    let subtitle: String
+    let selected: Bool
+    let tap: () -> Void
+
+    var body: some View {
+        Button(action: tap) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(.ultraThinMaterial)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(selected ? Color.accentColor.opacity(0.8) : Color.secondary.opacity(0.12), lineWidth: selected ? 2 : 1)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Color.accentColor.opacity(selected ? 0.08 : 0))
+            )
+        }
+        .buttonStyle(.plain)
     }
 }
 
@@ -460,8 +724,9 @@ private struct RateTile: View {
     let rate: Double
     let current: Double
     let tap: () -> Void
+
     var body: some View {
-        OptionTile(label: label, selected: current == rate, tap: tap)
+        SelectableTile(label: label, selected: current == rate, tap: tap)
     }
 }
 
@@ -469,8 +734,184 @@ private struct BufferTile: View {
     let size: Int
     let current: Int
     let tap: () -> Void
+
     var body: some View {
-        OptionTile(label: "\(size)", selected: current == size, tap: tap)
+        SelectableTile(label: "\(size)", selected: current == size, tap: tap)
+    }
+}
+
+private struct ChannelModeTile: View {
+    let label: String
+    let selected: Bool
+    var disabled: Bool = false
+    let tap: () -> Void
+
+    var body: some View {
+        SelectableTile(label: label, selected: selected, disabled: disabled, tap: tap)
+    }
+}
+
+private struct SelectableTile: View {
+    let label: String
+    let selected: Bool
+    var disabled: Bool = false
+    let tap: () -> Void
+
+    var body: some View {
+        Button(action: tap) {
+            Text(label)
+                .font(.subheadline.weight(.semibold))
+                .frame(maxWidth: .infinity)
+                .frame(height: 54)
+        }
+        .buttonStyle(.plain)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(.ultraThinMaterial)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(selected ? Color.accentColor.opacity(0.8) : Color.secondary.opacity(0.12), lineWidth: selected ? 2 : 1)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.accentColor.opacity(selected ? 0.08 : 0))
+        )
+        .opacity(disabled ? 0.5 : 1)
+        .disabled(disabled)
+    }
+}
+
+private struct DeviceTile: View {
+    let title: String
+    let subtitle: String
+    let symbol: String
+    let selected: Bool
+    let tap: () -> Void
+
+    var body: some View {
+        Button(action: tap) {
+            VStack(alignment: .leading, spacing: 8) {
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(.ultraThinMaterial)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .stroke(selected ? Color.accentColor.opacity(0.85) : Color.secondary.opacity(0.15), lineWidth: selected ? 2 : 1)
+                    )
+                    .frame(height: 64)
+                    .overlay(
+                        Image(systemName: symbol)
+                            .symbolRenderingMode(.palette)
+                            .foregroundStyle(.primary, .secondary)
+                            .font(.system(size: 22, weight: .semibold))
+                    )
+                Text(title)
+                    .font(.subheadline)
+                    .lineLimit(1)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .padding(10)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct BadgeText: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(.ultraThinMaterial, in: Capsule())
+            .overlay(Capsule().stroke(Color.secondary.opacity(0.12), lineWidth: 1))
+    }
+}
+
+private struct MicrophonePermissionCTA: View {
+    let status: MicrophonePermission.Status
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: "mic.slash.fill")
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(.red, .secondary)
+                    .font(.title3)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Enable Microphone Access")
+                        .font(.subheadline.weight(.semibold))
+                    Text(status == .denied
+                         ? "Microphone access is off. Open Settings to re-enable."
+                         : "Allow access to list inputs and monitor audio.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .foregroundStyle(.secondary)
+            }
+            .padding(12)
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(Color.secondary.opacity(0.15), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct DiagnosticsSection: View {
+    let outputs: [AudioSessionController.RouteOutputInfo]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Current Route Outputs")
+                .font(.subheadline.weight(.semibold))
+
+            if outputs.isEmpty {
+                Text("No active outputs")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(outputs) { output in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(output.name)
+                            .font(.caption.weight(.semibold))
+                        Text("\(output.portType.rawValue) · uid \(output.uid)")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct DiagnosticsRow: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label)
+                .font(.caption.weight(.semibold))
+            Spacer()
+            Text(value)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.trailing)
+        }
     }
 }
 
@@ -481,10 +922,22 @@ private struct EmptyDevicesFallback: View {
                 .symbolRenderingMode(.palette)
                 .foregroundStyle(.yellow, .white)
                 .imageScale(.medium)
-            Text("No input devices reported. iOS may restrict microphone access until you grant permission or start the engine.")
+            Text("No input devices reported. Grant microphone access or start the engine to refresh inputs.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
         }
         .padding(.vertical, 2)
+    }
+}
+
+private extension AVAudioSession.CategoryOptions {
+    var prettyList: String {
+        var items: [String] = []
+        if contains(.mixWithOthers) { items.append("mixWithOthers") }
+        if contains(.allowBluetooth) { items.append("allowBluetooth") }
+        if contains(.allowBluetoothA2DP) { items.append("allowBluetoothA2DP") }
+        if contains(.allowAirPlay) { items.append("allowAirPlay") }
+        if contains(.defaultToSpeaker) { items.append("defaultToSpeaker") }
+        return items.isEmpty ? "none" : items.joined(separator: ", ")
     }
 }


### PR DESCRIPTION
### Motivation

- Unblock background decoding tasks that were failing due to `@MainActor` isolation errors by allowing decode helpers to be called off-main.  
- Provide a centralized, observable audio routing surface and robust Pro Audio settings UI to surface route/engine state and diagnostics.  
- Make the tone engine safer to reinitialize during route changes so active voices/engine state are not left half-active or crash the app.  

### Description

- Mark `CommunityPacksStore` decoding helpers and related utilities as `nonisolated` (e.g. `decodeSchema`, `decodeScalePayload`, `decodeSchemaOffMain`, `decodeScalePayloadOffMain`, `communityPacksDecoder`, ISO8601 formatters and logging helpers) so detached background `Task`s can call them without violating `@MainActor` isolation and to resolve the compile-time errors reported.  
- Add `AudioSessionController` (`@MainActor`, `ObservableObject`) as a shared controller exposing engine state, route outputs/summary, negotiated SR/buffer/channels, input list, preferences, diagnostics text and a safe `reinitializeOutputRoute()` flow that snapshots voices, fades/stops and reapplies session prefs.  
- Extend `ToneOutputEngine` with safer helpers including richer `VoiceSnapshot` (`ownerKey`), `snapshotActiveVoices()`, `fadeOutAllVoices(releaseSeconds:)`, `hardStopEngine(deactivateSession:)`, `isEngineRunning` and `activeVoiceCount()` to enable safe reinitialization without duplicating AVAudioSession management.  
- Rewrite `ProAudioSettingsView` to use the new `AudioSessionController`, add routing/engine/inputs/diagnostics cards and a native `AVRoutePickerView` wrapper, plus UI components for presets, advanced overrides, reinitialize CTA and diagnostics copy.  

### Testing

- Automated tests: none executed for this patch.  
- The actor-isolation compile errors reported for `CommunityPacksStore` were addressed by marking the decoding helpers and formatters `nonisolated`, and changes were committed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69717882584c8327bc8ddc8ddbc56eb6)