### PR TITLE
Community Packs: unify Preview & scale selector, remove dropdown, restyle Install, preserve scale titles

### DIFF
--- a/Tenney/CommunityPacksStore.swift
+++ b/Tenney/CommunityPacksStore.swift
@@ -334,8 +334,10 @@ final class CommunityPacksStore: ObservableObject {
         id: UUID,
         provenance: TenneyScale.Provenance?
     ) -> TenneyScale {
-        let title = scale.payload.title.trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolvedName = title.isEmpty ? scale.title : title
+        // Keep INDEX.json titles attached so installed packs retain per-scale names.
+        let indexTitle = scale.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let payloadTitle = scale.payload.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedName = indexTitle.isEmpty ? payloadTitle : indexTitle
         return TenneyScale(
             id: id,
             name: resolvedName,

--- a/Tenney/PackPrimaryActionMode.swift
+++ b/Tenney/PackPrimaryActionMode.swift
@@ -25,25 +25,13 @@ struct PackPrimaryActionButton: View {
     var corner: CGFloat = 12
 
     private var isDisabled: Bool { (!isEnabled) || isBusy }
-    private var isPreview: Bool {
-        if case .preview = mode { return true }
-        return false
-    }
-
     var body: some View {
         Group {
             switch mode {
-            case .preview:
+            case .preview, .install, .update:
                 Button(action: action) { label }
                     .buttonStyle(GlassPressFeedback())
                     .modifier(GlassRoundedRect(corner: corner))
-
-            case .install(let tint), .update(let tint):
-                // Keep the existing path: borderedProminent + tint.
-                Button(action: action) { label }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.large)
-                    .tint(tint)
             }
         }
         .disabled(isDisabled)
@@ -53,7 +41,9 @@ struct PackPrimaryActionButton: View {
     private var label: some View {
         HStack(spacing: 8) {
             if isBusy {
-                ProgressView().controlSize(.small)
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(labelForeground)
             } else {
                 symbol
             }
@@ -62,8 +52,8 @@ struct PackPrimaryActionButton: View {
                 .font(.callout.weight(.semibold))
         }
         .frame(maxWidth: .infinity, minHeight: 44)
-        .padding(.horizontal, isPreview ? 14 : 0)
-        .foregroundStyle(.primary)
+        .padding(.horizontal, 14)
+        .foregroundStyle(labelForeground)
     }
 
     @ViewBuilder
@@ -73,6 +63,15 @@ struct PackPrimaryActionButton: View {
                 .symbolEffect(.bounce, value: animateSymbol)
         } else {
             Image(systemName: systemImage)
+        }
+    }
+
+    private var labelForeground: Color {
+        switch mode {
+        case .install(let tint), .update(let tint):
+            return tint ?? .primary
+        case .preview:
+            return .primary
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Remove the redundant middle scale dropdown in the pack detail action bar and unify preview + scale selection into a single control to match the intended UX.  
- Make the install/update primary control visually match Preview (no giant pill) to reduce visual churn.  
- Fix the data regression where installed packs lost individual scale titles by ensuring index metadata titles are preserved when creating installed scales.  

### Description
- UI: removed the separate scale selector from the bottom action toolbar and replaced the toolbar layout so it only exposes a unified `Preview` control and the primary `Install/Update/Installed` control, implemented in `Tenney/CommunityPacksViews.swift`.  
- UI: `Preview` is now conditional — when `isInstalled` it is a `Menu` listing `pack.scales`, otherwise it is a plain `Preview` button that previews the default scale; chevron shown only in installed state.  
- Styling: unified primary button visuals by reusing the existing glass button treatment (`GlassRoundedRect`/`GlassPressFeedback`) and matching height/corner radius in `Tenney/PackPrimaryActionMode.swift` so Install/Update shares Preview's visual weight rather than using a large `borderedProminent` pill.  
- Model fix: preserve INDEX.json scale titles as the source of truth when constructing `TenneyScale` for preview/install by preferring `CommunityPackScaleViewModel.title` over regenerated filenames or payload names; changes applied in `Tenney/CommunityPacksStore.swift` and used by `communityScaleForFiltering` in `Tenney/CommunityPacksViews.swift`.  An inline comment was added to explain why index titles are kept.  
- Small behavioral adjustments: primary button mode / titles/icons adjusted so the toolbar reflects `Preview` + `Install/Update/Installed` states and preview actions are disabled when appropriate without adding new APIs or altering networking/caching.  

### Testing
- No automated tests were executed for this change.  
- Changes are constrained to `Tenney/CommunityPacksViews.swift`, `Tenney/CommunityPacksStore.swift`, and `Tenney/PackPrimaryActionMode.swift` and do not change public APIs or networking/caching logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697191163c848327b6f502184360fe89)