### PR TITLE
Implement Monochrome Ink Scope trace style

### DIFF
--- a/Tenney/LissajousRenderer.swift
+++ b/Tenney/LissajousRenderer.swift
@@ -303,7 +303,10 @@ final class LissajousRenderer: NSObject, MTKViewDelegate {
             return SIMD4(1,1,1,Float(alpha))
             #endif
         }
-        let stroke = rgba(theme.scopeTraceDefault, alpha: 0.9)
+        let strokeColor = theme.idRaw == LatticeThemeID.monochrome.rawValue
+            ? theme.scopeInkPair().ink
+            : theme.scopeTraceDefault
+        let stroke = rgba(strokeColor, alpha: 0.9)
 
         // Build verts
         var verts: [VSIn] = []
@@ -457,8 +460,14 @@ final class LissajousRenderer: NSObject, MTKViewDelegate {
             return SIMD4<Float>(0.95, 0.95, 0.95, Float(alpha))
             #endif
         }
-        coreColor = rgba(theme.e3, alpha: 0.85)
-        sheenColor = rgba(theme.scopeTraceDefault, alpha: 0.95)
+        if theme.idRaw == LatticeThemeID.monochrome.rawValue {
+            let inks = theme.scopeInkPair()
+            coreColor = rgba(inks.deepInk, alpha: 0.85)
+            sheenColor = rgba(inks.ink, alpha: 0.95)
+        } else {
+            coreColor = rgba(theme.e3, alpha: 0.85)
+            sheenColor = rgba(theme.scopeTraceDefault, alpha: 0.95)
+        }
     }
 
     // MARK: - Persistence targets
@@ -522,7 +531,10 @@ final class LissajousRenderer: NSObject, MTKViewDelegate {
                 return SIMD4(1,1,1,Float(alpha))
                 #endif
             }
-            let stroke = rgba(theme.scopeTraceDefault, alpha: 0.9)
+            let strokeColor = theme.idRaw == LatticeThemeID.monochrome.rawValue
+                ? theme.scopeInkPair().ink
+                : theme.scopeTraceDefault
+            let stroke = rgba(strokeColor, alpha: 0.9)
 
             let pptr = livePointBuffer!.contents().bindMemory(to: VSIn.self, capacity: max(1, livePointCount))
             if livePointCount > 0 {

--- a/Tenney/PhaseScopeTunerView.swift
+++ b/Tenney/PhaseScopeTunerView.swift
@@ -264,9 +264,20 @@ private struct ScopeTrace: View {
                 path.move(to: map(points[0]))
                 for p in points.dropFirst() { path.addLine(to: map(p)) }
 
-                ctx.stroke(path,
-                           with: .color(theme.scopeTraceDefault.opacity(alpha)),
-                           style: StrokeStyle(lineWidth: 1.8, lineCap: .round, lineJoin: .round))
+                if theme.idRaw == LatticeThemeID.monochrome.rawValue {
+                    ScopeTraceStyle.strokeMonochrome(
+                        path: path,
+                        in: &ctx,
+                        theme: theme,
+                        coreWidth: 1.8,
+                        sheenWidth: 0.9,
+                        alpha: alpha
+                    )
+                } else {
+                    ctx.stroke(path,
+                               with: .color(theme.scopeTraceDefault.opacity(alpha)),
+                               style: StrokeStyle(lineWidth: 1.8, lineCap: .round, lineJoin: .round))
+                }
             }
             .blur(radius: blur)
             .opacity(referenceOn ? 1.0 : 0.0)

--- a/Tenney/ScopeTraceStyle.swift
+++ b/Tenney/ScopeTraceStyle.swift
@@ -1,0 +1,59 @@
+//
+//  ScopeTraceStyle.swift
+//  Tenney
+//
+//  Created by OpenAI on 2025-02-14.
+//
+
+import SwiftUI
+
+enum ScopeTraceStyle {
+    static func strokeMonochrome(
+        path: Path,
+        in context: inout GraphicsContext,
+        theme: ResolvedTenneyTheme,
+        coreWidth: CGFloat,
+        sheenWidth: CGFloat,
+        alpha: Double = 1.0,
+        bloom: Bool = true
+    ) {
+        let inks = theme.scopeInkPair()
+        let ink = inks.ink.opacity(alpha)
+        let deepInk = inks.deepInk.opacity(alpha)
+
+        let coreGradient = Gradient(colors: [ink, deepInk])
+        let sheenGradient = Gradient(colors: [ink.opacity(0.55), .clear])
+
+        let coreStyle = StrokeStyle(lineWidth: coreWidth, lineCap: .round, lineJoin: .round)
+        let sheenStyle = StrokeStyle(lineWidth: sheenWidth, lineCap: .round, lineJoin: .round)
+
+        if bloom {
+            context.drawLayer { layer in
+                layer.addFilter(.blur(radius: 2))
+                layer.stroke(
+                    path,
+                    with: .linearGradient(
+                        LinearGradient(gradient: coreGradient, startPoint: .leading, endPoint: .trailing)
+                    ),
+                    style: StrokeStyle(lineWidth: coreWidth + 2, lineCap: .round, lineJoin: .round)
+                )
+            }
+        }
+
+        context.stroke(
+            path,
+            with: .linearGradient(
+                LinearGradient(gradient: coreGradient, startPoint: .leading, endPoint: .trailing)
+            ),
+            style: coreStyle
+        )
+
+        context.stroke(
+            path,
+            with: .linearGradient(
+                LinearGradient(gradient: sheenGradient, startPoint: .leading, endPoint: .trailing)
+            ),
+            style: sheenStyle
+        )
+    }
+}

--- a/Tenney/ThemePreviewComponents.swift
+++ b/Tenney/ThemePreviewComponents.swift
@@ -89,7 +89,17 @@ struct ThemeScopeMicroPreview: View {
                 if i == 0 { p.move(to: CGPoint(x: x, y: y)) }
                 else { p.addLine(to: CGPoint(x: x, y: y)) }
             }
-            ctx.stroke(p, with: .color(theme.scopeTraceDefault), lineWidth: 1.4)
+            if theme.idRaw == LatticeThemeID.monochrome.rawValue {
+                ScopeTraceStyle.strokeMonochrome(
+                    path: p,
+                    in: &ctx,
+                    theme: theme,
+                    coreWidth: 1.6,
+                    sheenWidth: 0.8
+                )
+            } else {
+                ctx.stroke(p, with: .color(theme.scopeTraceDefault), lineWidth: 1.4)
+            }
         }
         .frame(height: 22)
         .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))


### PR DESCRIPTION
### Motivation
- Provide a best-in-class layered “Monochrome Ink Scope” rendering for the Monochrome theme that uses the user-selected tint and a derived darker, more saturated deep-ink tone. 
- Keep this behavior surgical and scoped to the scope drawing layer so other themes remain unchanged and performance implications are minimized. 

### Description
- Added `func scopeInkPair()` and `private static func deepInk(from:isDark:)` on `ResolvedTenneyTheme` to derive `ink` and `deepInk` from the user-preference `SettingsKeys.tenneyMonochromeTintHex` and to fall back to a safe mixed color when HSB conversion is unavailable. 
- Introduced a shared helper `ScopeTraceStyle.strokeMonochrome(...)` (`Tenney/ScopeTraceStyle.swift`) that draws the three-layer trace (optional bloom behind core, core gradient `ink → deepInk`, and sheen gradient `ink.opacity(0.55) → .clear`) with round caps/joins and configurable widths. 
- Wired the new style into the UI in two places so the preview and real scope reuse the same code: `ThemeScopeMicroPreview` (uses `ScopeTraceStyle.strokeMonochrome`) and `ScopeTrace` inside `PhaseScopeTunerView`; updated the Metal renderer (`LissajousRenderer`) to use the monochrome `ink`/`deepInk` pair for ribbon core/sheens while preserving existing behavior for non-monochrome themes. 
- Implementation notes: `deepInk` tries HSB conversion (`UIColor`/`NSColor`) to preserve hue and increase saturation / reduce brightness; when that isn’t available a fallback mixes toward black and slightly reintroduces tint to approximate increased saturation. 

### Testing
- No automated tests were executed as part of this change. 
- Manual verification checklist (to run locally): switch to Monochrome theme and adjust `tenneyMonochromeTintHex` to confirm micro-preview and the real oscilloscope show layered core+sheen(+bloom) using the selected hue, and confirm other themes render exactly as before.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972aae129788327938880b87572306f)