### PR TITLE
Fix oscilloscope theme propagation and live monochrome tint updates

### DIFF
--- a/Tenney/ContentView.swift
+++ b/Tenney/ContentView.swift
@@ -24,12 +24,14 @@ struct ContentView: View {
     @AppStorage(SettingsKeys.tenneyThemeMixBasis) private var mixBasisRaw: String = TenneyMixBasis.complexityWeight.rawValue
     @AppStorage(SettingsKeys.tenneyThemeMixMode) private var mixModeRaw: String = TenneyMixMode.blend.rawValue
     @AppStorage(SettingsKeys.tenneyThemeScopeMode) private var scopeModeRaw: String = TenneyScopeColorMode.constant.rawValue
+    @AppStorage(SettingsKeys.tenneyMonochromeTintHex) private var monochromeTintHex: String = "#000000"
 
     @AppStorage(SettingsKeys.setupWizardDone) private var setupWizardDone: Bool = false
 private let libraryStore = ScaleLibraryStore.shared
     @Environment(\.colorScheme) private var systemScheme
     @AppStorage(SettingsKeys.latticeThemeStyle) private var themeStyleRaw: String = "system"
     private var resolvedTheme: ResolvedTenneyTheme {
+        let _ = monochromeTintHex
         TenneyThemeRegistry.resolvedCurrent(
             themeIDRaw: tenneyThemeIDRaw,
             scheme: effectiveIsDark ? .dark : .light,

--- a/Tenney/ScaleBuilderScreen.swift
+++ b/Tenney/ScaleBuilderScreen.swift
@@ -19,18 +19,13 @@ struct ScaleBuilderScreen: View {
     @AppStorage(SettingsKeys.lissaDotSize)    private var lissaDotSize: Double = 2.0
     @AppStorage(SettingsKeys.lissaLiveSamples) private var lissaLiveSamples: Int = 768
     @AppStorage(SettingsKeys.lissaGlobalAlpha) private var lissaGlobalAlpha: Double = 1.0
-    @AppStorage(SettingsKeys.latticeThemeID) private var latticeThemeID: String = LatticeThemeID.classicBO.rawValue
-    @AppStorage(SettingsKeys.latticeThemeStyle) private var themeStyleRaw: String = ThemeStyleChoice.system.rawValue
     @AppStorage(SettingsKeys.accidentalPreference) private var accidentalPreferenceRaw: String = AccidentalPreference.auto.rawValue
     @AppStorage(SettingsKeys.staffA4Hz) private var staffA4Hz: Double = 440
 
-    @Environment(\.colorScheme) private var systemScheme
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
-    private var effectiveIsDark: Bool {
-        (themeStyleRaw == "dark") || (themeStyleRaw == "system" && systemScheme == .dark)
-    }
-    
+    @Environment(\.tenneyTheme) private var theme
+
     private func finishBuilder() {
         persistBuilderDraftToSession(reason: "done")
         didPersistOnDismiss = true
@@ -647,11 +642,6 @@ struct ScaleBuilderScreen: View {
             // Large tap zones for performance; two columns by default
             ScrollView {
                 VStack(spacing: 10) {
-                    let theme = ThemeRegistry.theme(
-                        LatticeThemeID(rawValue: latticeThemeID) ?? .classicBO,
-                        dark: effectiveIsDark
-                    )
-
                     let pairs = builderLissajousPairs
                     let ch = builderLissajousChannels
 

--- a/Tenney/Settings.swift
+++ b/Tenney/Settings.swift
@@ -391,6 +391,7 @@ struct StudioConsoleView: View {
     @AppStorage(SettingsKeys.tenneyThemeMixBasis) private var mixBasisRaw: String = TenneyMixBasis.complexityWeight.rawValue
     @AppStorage(SettingsKeys.tenneyThemeMixMode) private var mixModeRaw: String = TenneyMixMode.blend.rawValue
     @AppStorage(SettingsKeys.tenneyThemeScopeMode) private var scopeModeRaw: String = TenneyScopeColorMode.constant.rawValue
+    @AppStorage(SettingsKeys.tenneyMonochromeTintHex) private var monochromeTintHex: String = "#000000"
     @EnvironmentObject private var tunerRailStore: TunerRailStore
     @State private var showTunerRailPalette: Bool = false
     @State private var shouldScrollToTunerRail: Bool = false
@@ -2718,6 +2719,7 @@ struct StudioConsoleView: View {
     
     // MARK: - Body (split to keep type-checker happy)
     var body: some View {
+        let _ = monochromeTintHex
                 NavigationStack {
                     contentStack
                         .navigationBarBackButtonHidden(true)
@@ -3878,11 +3880,6 @@ private struct GlassNavTile<Destination: View>: View {
             subtitle: ""
         ) {
             VStack(alignment: .leading, spacing: 12) {
-                let theme = ThemeRegistry.theme(
-                    LatticeThemeID(rawValue: tenneyThemeIDRaw) ?? .classicBO,
-                    dark: effectiveIsDark
-                )
-
                 // ✅ static preview window (same “preview then pager” pattern as Lattice UI)
                 LissajousPreviewFrame(contentPadding: 0, showsFill: false) {
                     LissajousCanvasPreview(


### PR DESCRIPTION
### Motivation
- Ensure both Builder and Settings oscilloscopes resolve and use the same theme from the Environment so scope trace colors follow the user-selected theme immediately.
- Make Monochrome theme updates (user tint chips at `SettingsKeys.tenneyMonochromeTintHex`) propagate live without stale cached colors.
- Apply minimal, surgical changes to avoid refactors, preserve previews/performance, and avoid publishing-from-view-update warnings.

### Description
- Builder oscilloscope now reads the resolved theme from the Environment via `@Environment(\.tenneyTheme)` and uses `theme` tokens for Lissajous previews instead of locally resolving `ThemeRegistry.theme` (changes in `Tenney/ScaleBuilderScreen.swift`).
- Settings view stopped building a separate `ThemeRegistry.theme` for its preview and instead uses the injected `tenneyTheme` (changes in `Tenney/Settings.swift`).
- To ensure the global resolved theme recomputes when the monochrome tint changes, `@AppStorage(SettingsKeys.tenneyMonochromeTintHex)` was wired into top-level theme resolution points and referenced (via `let _ = monochromeTintHex`) in `Tenney/ContentView.swift` and `Tenney/Settings.swift` so SwiftUI invalidates/recomputes the resolved theme when the user updates the monochrome tint.
- Kept changes narrowly scoped (no large refactors), avoided publishing state from view updates, and left existing scope renderer logic intact (only changed where the color tokens are sourced).

### Testing
- No automated tests were executed in this rollout.
- Change set was limited to view wiring and AppStorage references to trigger theme recomputation; intended validation is to run the app and verify: switching themes in Settings immediately updates Builder scope, and changing the Monochrome tint updates the Settings scope live without relaunch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972af2a749483279c88d61403968e15)