### PR TITLE
Add Nocturne readable scene background preset and tune Nocturne theme for legibility

### DIFF
--- a/Tenney/LatticeTheme.swift
+++ b/Tenney/LatticeTheme.swift
@@ -168,15 +168,15 @@ struct ThemeRegistry {
             
         case .nocturneBO:
             return LatticeTheme(
-                e3: Color(hex: "#80B3FF"),
-                e5: Color(hex: "#FFB47B"),
+                e3: Color(hex: "#B35133"),
+                e5: Color(hex: "#C9A448"),
                 mix: .blendByWeight,
                 isDark: dark,
-                axisE3: Color.white.opacity(0.14),
-                axisE5: Color.white.opacity(0.14),
-                path: Color.white.opacity(0.58),
-                labelPrimary: Color(hex: "#D9E3F7"),
-                labelSecondary: Color(hex: "#9AA9C1"),
+                axisE3: Color(hex: "#B35133").opacity(dark ? 0.20 : 0.14),
+                axisE5: Color(hex: "#C9A448").opacity(dark ? 0.20 : 0.14),
+                path: Color(hex: dark ? "#EFE6D9" : "#2A211C").opacity(dark ? 0.60 : 0.50),
+                labelPrimary: dark ? Color(hex: "#F2EADF") : Color(hex: "#1A1410"),
+                labelSecondary: dark ? Color(hex: "#B9B0A4") : Color(hex: "#5C5046"),
                 overlayPrime: overlayNocturne(dark: dark)
             )
         }
@@ -298,10 +298,10 @@ struct ThemeRegistry {
     // Nocturne: cool night tones with neon warmth
     private static func overlayNocturne(dark: Bool) -> [Int:Color] {
         dark
-        ? palette([ 7:"#C7A1FF", 11:"#77E4DD", 13:"#FFA7C6", 17:"#F4D37B",
-                    19:"#ADEF77", 23:"#9EDCFF", 29:"#E3A9FF", 31:"#FFBE94"])
-        : palette([ 7:"#AD88FF", 11:"#55D6D1", 13:"#FF94B4", 17:"#F2C259",
-                    19:"#86DF63", 23:"#7FD2FF", 29:"#D389FF", 31:"#FFAC7A"])
+        ? palette([ 7:"#9A6A52", 11:"#6F7A4A", 13:"#8B3F3B", 17:"#C2A35C",
+                    19:"#4F6B5B", 23:"#5B6A7A", 29:"#7A4A5A", 31:"#B07B52"])
+        : palette([ 7:"#8A5B46", 11:"#5C6B3E", 13:"#783536", 17:"#B08E45",
+                    19:"#3E5C4E", 23:"#4B5C6D", 29:"#693C4C", 31:"#9A6846"])
     }
     
 }

--- a/Tenney/LatticeView.swift
+++ b/Tenney/LatticeView.swift
@@ -4118,6 +4118,7 @@ struct LatticeView: View {
             ZStack {
                         TenneySceneBackground(
                             isDark: effectiveIsDark,
+                            preset: activeTheme.sceneBackgroundPreset,
                             tintA: activeTheme.primeTint(3),
                             tintB: activeTheme.primeTint(5)
                         )

--- a/Tenney/MacRootView.swift
+++ b/Tenney/MacRootView.swift
@@ -5,17 +5,20 @@ struct MacRootView: View {
     @EnvironmentObject private var latticeStore: LatticeStore
     @EnvironmentObject private var app: AppModel
     @Environment(\.colorScheme) private var scheme
+    @Environment(\.tenneyTheme) private var theme
     @Environment(\.openWindow) private var openWindow
 
     @SceneStorage("tenney.mac.splitRatio") private var splitRatio: Double = 0.56
     @State private var stageActive = false
 
-    private var tintA: Color { TenneyTokens.Color.prime3 }
-    private var tintB: Color { TenneyTokens.Color.prime5 }
-
     var body: some View {
         ZStack(alignment: .top) {
-            TenneySceneBackground(isDark: scheme == .dark, tintA: tintA, tintB: tintB)
+            TenneySceneBackground(
+                isDark: scheme == .dark,
+                preset: theme.sceneBackgroundPreset,
+                tintA: theme.primeTint(3),
+                tintB: theme.primeTint(5)
+            )
 
             VStack(spacing: 0) {
                 ResizableSplitView(

--- a/Tenney/TenneyTheme.swift
+++ b/Tenney/TenneyTheme.swift
@@ -42,6 +42,11 @@ public enum TenneyScopeColorMode: String, CaseIterable, Identifiable {
     public var id: String { rawValue }
 }
 
+public enum TenneySceneBackgroundPreset: String, Codable, CaseIterable {
+    case standardAtmospheric
+    case nocturneReadable
+}
+
 // MARK: - Ratio signature (stable key)
 public struct RatioSignature: Hashable, Sendable {
     public struct PrimeExp: Hashable, Sendable {
@@ -100,6 +105,7 @@ public struct ResolvedTenneyTheme: Equatable {
          name: String,
          scheme: ColorScheme,
          palette: [Int: Color],
+         sceneBackgroundPreset: TenneySceneBackgroundPreset,
          surfaceTint: Color,
          chromaShadow: Color,
          tunerNeedle: Color,
@@ -116,6 +122,7 @@ public struct ResolvedTenneyTheme: Equatable {
          self.name = name
          self.scheme = scheme
          self.palette = palette
+         self.sceneBackgroundPreset = sceneBackgroundPreset
          self.surfaceTint = surfaceTint
          self.chromaShadow = chromaShadow
          self.tunerNeedle = tunerNeedle
@@ -136,6 +143,8 @@ public struct ResolvedTenneyTheme: Equatable {
 
     // Prime palette (includes 3/5 + overlays)
     private let palette: [Int: Color]
+
+    public let sceneBackgroundPreset: TenneySceneBackgroundPreset
 
     // Surface tint (“museum glass”, subtle, scheme-aware)
     public let surfaceTint: Color        // already contains strength via opacity

--- a/Tenney/TenneyThemeRegistry.swift
+++ b/Tenney/TenneyThemeRegistry.swift
@@ -100,6 +100,7 @@ enum TenneyThemeRegistry {
             name: id.displayName,
             scheme: scheme,
             palette: pal,
+            sceneBackgroundPreset: id == .nocturneBO ? .nocturneReadable : .standardAtmospheric,
             surfaceTint: surfaceTint,
             chromaShadow: chromaShadow,
             tunerNeedle: base.primeTint(5),
@@ -159,6 +160,7 @@ enum TenneyThemeRegistry {
             name: t.name,
             scheme: scheme,
             palette: pal,
+            sceneBackgroundPreset: .standardAtmospheric,
             surfaceTint: surfaceTint,
             chromaShadow: chromaShadow,
             tunerNeedle: Color(hex: t.tunerNeedleHex),
@@ -173,4 +175,3 @@ enum TenneyThemeRegistry {
         )
     }
 }
-


### PR DESCRIPTION
### Motivation
- Provide a dedicated “Nocturne readable” scene background (paper in light, slate in dark) to make the Tuner + Lattice surfaces easier to read without changing other themes.
- Keep changes minimal and theme-driven so existing visuals for non-Nocturne remain identical and call sites are not forked.

### Description
- Add `TenneySceneBackgroundPreset` and a `sceneBackgroundPreset` field on `ResolvedTenneyTheme` in `Tenney/TenneyTheme.swift` and default custom/builtin resolved themes to `.standardAtmospheric`, routing `nocturneBO` to `.nocturneReadable` in `Tenney/TenneyThemeRegistry.swift`.
- Extend `TenneySceneBackground` (`Tenney/TenneySceneBackground.swift`) with a `preset` parameter and implement the `nocturneReadable` visuals (light paper base `#F6F0E6` with `#FFF9F1` top lift, umber vignette tint `#2A1F18`, ambient bloom `#C96A3A/#D7B25A`; dark slate base `#0C121A` with `#243244` lift, vignette `#05070A`, ambient bloom `#D07A44/#E2C06A` and reduced opacities) while preserving exact behavior for `.standardAtmospheric`.
- Wire the preset through existing call sites so the background is theme-driven by replacing `TenneySceneBackground(isDark:…, tintA:, tintB:)` with `TenneySceneBackground(isDark:…, preset: theme.sceneBackgroundPreset, tintA: theme.primeTint(3), tintB: theme.primeTint(5))` in `Tenney/LatticeView.swift` and `Tenney/MacRootView.swift`.
- Tune the Nocturne `LatticeTheme` (`Tenney/LatticeTheme.swift`) to the spec by setting `e3`/`e5` to `#B35133`/`#C9A448`, adjusting `axisE3`/`axisE5`, `labelPrimary`/`labelSecondary`, `path` per scheme, and replacing the 7–31 overlay primes with a custom lower-chroma printmaking palette (unique hexes) to avoid repeating other themes.
- Ensure custom themes keep the default `.standardAtmospheric` preset and preserve all previous mix/mode behavior and surface tint logic.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972b1e9316883279751d02581fe1148)