### PR TITLE
Align tuner learn steps with tour and emit deterministic LearnEvent hooks

### DIFF
--- a/Tenney/Components/TunerUI.swift
+++ b/Tenney/Components/TunerUI.swift
@@ -103,11 +103,25 @@ final class TunerStore: ObservableObject {
     @Published var primeLimit: Int = {
         let v = UserDefaults.standard.integer(forKey: SettingsKeys.tunerPrimeLimit)
         return (v == 0 ? 11 : v)
-    }() { didSet { UserDefaults.standard.set(primeLimit, forKey: SettingsKeys.tunerPrimeLimit) } }
+    }() {
+        didSet {
+            if oldValue != primeLimit {
+                LearnEventBus.shared.send(.tunerPrimeLimitChanged(limitRaw: "\(primeLimit)"))
+            }
+            UserDefaults.standard.set(primeLimit, forKey: SettingsKeys.tunerPrimeLimit)
+        }
+    }
 
     @Published var stageMode: Bool = {
         UserDefaults.standard.object(forKey: SettingsKeys.tunerStageMode) as? Bool ?? false
-    }() { didSet { UserDefaults.standard.set(stageMode, forKey: SettingsKeys.tunerStageMode) } }
+    }() {
+        didSet {
+            if oldValue != stageMode {
+                LearnEventBus.shared.send(.tunerStageModeChanged(stageMode))
+            }
+            UserDefaults.standard.set(stageMode, forKey: SettingsKeys.tunerStageMode)
+        }
+    }
 
     @Published var modeRaw: String = {
         (UserDefaults.standard.string(forKey: SettingsKeys.tunerMode) ?? TunerUIMode.auto.rawValue)
@@ -118,7 +132,14 @@ final class TunerStore: ObservableObject {
     @Published var viewStyleRaw: String = {
         UserDefaults.standard.string(forKey: SettingsKeys.tunerViewStyle)
         ?? TunerViewStyle.Gauge.rawValue
-    }() { didSet { UserDefaults.standard.set(viewStyleRaw, forKey: SettingsKeys.tunerViewStyle) } }
+    }() {
+        didSet {
+            if oldValue != viewStyleRaw {
+                LearnEventBus.shared.send(.tunerViewStyleChanged(styleRaw: viewStyleRaw))
+            }
+            UserDefaults.standard.set(viewStyleRaw, forKey: SettingsKeys.tunerViewStyle)
+        }
+    }
 
     var viewStyle: TunerViewStyle {
         get { TunerViewStyle(rawValue: viewStyleRaw) ?? .Gauge }

--- a/Tenney/LearnCoordinator.swift
+++ b/Tenney/LearnCoordinator.swift
@@ -63,10 +63,11 @@ final class LearnCoordinator: ObservableObject {
     private func handle(_ event: LearnEvent) {
         guard currentStepIndex < steps.count else { return }
         let step = steps[currentStepIndex]
+        let validated = step.validate(event)
 #if DEBUG
-        print("[LearnCoordinator] step \(currentStepIndex + 1)/\(steps.count) \"\(step.title)\" event=\(event)")
+        print("[LearnCoordinator] module=\(module) step \(currentStepIndex + 1)/\(steps.count) \"\(step.title)\" event=\(event) validated=\(validated)")
 #endif
-        if step.validate(event) {
+        if validated {
             advance()
         } else if gate.isActive, !isAttemptedDisallowedAction(event) {            LearnEventBus.shared.send(.attemptedDisallowedAction("\(event)"))
         }

--- a/Tenney/LearnEvents.swift
+++ b/Tenney/LearnEvents.swift
@@ -35,6 +35,11 @@ enum LearnEvent: Equatable, Sendable {
     case tunerConfidenceGateChanged(Double)
     case tunerOutputEnabledChanged(Bool)
     case tunerOutputWaveChanged(String)
+    case tunerViewStyleChanged(styleRaw: String)
+    case tunerPrimeLimitChanged(limitRaw: String)
+    case tunerStageModeChanged(Bool)
+    case tunerConfidenceInteracted
+    case tunerETJIDidInteract
 
     // Builder
     case builderPadTriggered(Int)

--- a/Tenney/LearnStepFactory.swift
+++ b/Tenney/LearnStepFactory.swift
@@ -79,53 +79,64 @@ enum LearnStepFactory {
         case .tuner:
             return [
                 LearnStep(
-                    title: "Pick a target",
-                    instruction: "Choose what you’re trying to match so the UI stops feeling ambiguous.",
-                    tryIt: "Pick any target ratio.",
-                    gate: .init(allowedTargets: ["tuner_target"], isActive: true),
-                    validate: { if case .tunerTargetPicked = $0 { return true } else { return false } }
+                    title: "Three tuner types",
+                    bullets: [
+                        "Gauge is minimal and calm; Chrono is more technical / explicit; Scope is more professional",
+                        "Both read the same pitch engine—only presentation changes."
+                    ],
+                    tryIt: "Switch between Gauge, Chrono, and Scope and notice what information is emphasized.",
+                    gate: .init(allowedTargets: ["tuner_view_switch"], isActive: true),
+                    validate: { if case .tunerViewStyleChanged = $0 { return true } else { return false } }
                 ),
                 LearnStep(
-                    title: "Lock target",
-                    instruction: "Lock fixes your target so the UI stops ‘chasing’ nearby ratios.",
-                    tryIt: "Toggle lock on/off.",
+                    title: "Confidence",
+                    bullets: [
+                        "Confidence is: how sure Tenney is that the detected pitch is stable + real.",
+                        "Low confidence usually means noise, breath, room tone, or unstable partials."
+                    ],
+                    tryIt: "Hum a steady tone, then stop—watch confidence rise/fall with stability.",
+                    gate: .init(allowedTargets: ["tuner_confidence"], isActive: true),
+                    validate: { $0 == .tunerConfidenceInteracted }
+                ),
+                LearnStep(
+                    title: "Lock target (long-press)",
+                    bullets: [
+                        "Lock fixes your target so the UI stops “chasing” nearby ratios.",
+                        "Use lock when practicing intonation against one goal."
+                    ],
+                    tryIt: "Long-press the target control to lock, then unlock.",
                     gate: .init(allowedTargets: ["tuner_lock"], isActive: true),
                     validate: { if case .tunerLockToggled = $0 { return true } else { return false } }
                 ),
                 LearnStep(
-                    title: "Root pitch",
-                    instruction: "Root is your reference. Changing it re-centers the whole JI world.",
-                    tryIt: "Change root once.",
-                    gate: .init(allowedTargets: ["tuner_root"], isActive: true),
-                    validate: { if case .tunerRootChanged = $0 { return true } else { return false } }
+                    title: "Prime limit chips",
+                    bullets: [
+                        "Prime limit changes which ratios are eligible matches.",
+                        "Lower limit = simpler vocabulary; higher limit = more nuance (and more ambiguity)."
+                    ],
+                    tryIt: "Change prime limit and watch the suggested ratio set tighten/expand.",
+                    gate: .init(allowedTargets: ["tuner_prime_limit"], isActive: true),
+                    validate: { if case .tunerPrimeLimitChanged = $0 { return true } else { return false } }
                 ),
                 LearnStep(
-                    title: "Pitch history",
-                    instruction: "History helps you see stability over time, not just instantaneous wiggle.",
-                    tryIt: "Open pitch history.",
-                    gate: .init(allowedTargets: ["tuner_history"], isActive: true),
-                    validate: { $0 == .tunerPitchHistoryOpened }
+                    title: "ET vs JI readouts",
+                    bullets: [
+                        "ET shows tempered note context; JI shows ratio context.",
+                        "They are complementary: ET for quick naming, JI for exactness."
+                    ],
+                    tryIt: "Play a stable pitch and compare the ET label vs the JI ratio.",
+                    gate: .init(allowedTargets: ["tuner_et_ji"], isActive: true),
+                    validate: { $0 == .tunerETJIDidInteract }
                 ),
                 LearnStep(
-                    title: "Confidence",
-                    instruction: "Confidence is how sure Tenney is that the pitch is stable + real.",
-                    tryIt: "Adjust the confidence gate once.",
-                    gate: .init(allowedTargets: ["tuner_confidence"], isActive: true),
-                    validate: { if case .tunerConfidenceGateChanged = $0 { return true } else { return false } }
-                ),
-                LearnStep(
-                    title: "Output",
-                    instruction: "Output lets you practice against a generated reference tone.",
-                    tryIt: "Toggle output on/off.",
-                    gate: .init(allowedTargets: ["tuner_output"], isActive: true),
-                    validate: { if case .tunerOutputEnabledChanged = $0 { return true } else { return false } }
-                ),
-                LearnStep(
-                    title: "Wave",
-                    instruction: "Wave changes the character of the reference tone.",
-                    tryIt: "Pick a different wave.",
-                    gate: .init(allowedTargets: ["tuner_wave"], isActive: true),
-                    validate: { if case .tunerOutputWaveChanged = $0 { return true } else { return false } }
+                    title: "Stage mode",
+                    bullets: [
+                        "Stage mode prioritizes readability and performance behavior.",
+                        "Expect fewer distractions and stronger visibility choices."
+                    ],
+                    tryIt: "Toggle stage mode and observe what UI elements simplify.",
+                    gate: .init(allowedTargets: ["tuner_stage_mode"], isActive: true),
+                    validate: { if case .tunerStageModeChanged = $0 { return true } else { return false } }
                 )
             ]
 


### PR DESCRIPTION
### Motivation
- Make the Tuner practice steps mirror the `LearnTenneyTour.tuner` narrative and ensure each step advances deterministically via a single, reliably-emitted `LearnEvent`. 
- Avoid depending on microphone input for progress by adding at least one guaranteed, harmless interaction per step. 
- Keep changes surgical and avoid changing normal tuner behavior outside Learn mode.

### Description
- Replaced the `.tuner` steps in `Tenney/LearnStepFactory.swift` with six tour-aligned steps (`Three tuner types`, `Confidence`, `Lock target (long-press)`, `Prime limit chips`, `ET vs JI readouts`, `Stage mode`) and set `LearnGate` allowed target IDs to `tuner_view_switch`, `tuner_confidence`, `tuner_lock`, `tuner_prime_limit`, `tuner_et_ji`, and `tuner_stage_mode` respectively, each validating on a single `LearnEvent`.
- Added new `LearnEvent` cases in `Tenney/LearnEvents.swift`: `tunerViewStyleChanged(styleRaw:)`, `tunerPrimeLimitChanged(limitRaw:)`, `tunerStageModeChanged(Bool)`, `tunerConfidenceInteracted`, and `tunerETJIDidInteract`.
- Emitted events from precise interaction points: `tunerViewStyleChanged` and `tunerPrimeLimitChanged` and `tunerStageModeChanged` from `TunerStore` `didSet`s in `Tenney/Components/TunerUI.swift`, and `tunerLockToggled` is preserved from lock toggle logic.
- Wired harmless tap affordances and targets in the UI (`Tenney/ContentView.swift`) so steps are deterministic: added `.onTapGesture` for the confidence readout and ET/JI readout that send `tunerConfidenceInteracted` and `tunerETJIDidInteract`, tagged components with `.learnTarget(id: ...)` and gated them via `.gated(..., gate: learnGate)`, and tagged the view-style switch, prime limit chips, lock area, and stage button with the requested IDs and gating.
- Enhanced debug tracing in `Tenney/LearnCoordinator.swift` to print module, step, event, and whether validation passed (debug-only output) to aid validation of gating and events.

### Testing
- No automated tests were executed against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972cd543edc83279534142dc178fcdd)