### PR TITLE
Add award-style completion screen and per-module progress badges for Learn Tenney

### DIFF
--- a/Tenney/LearnCoordinator.swift
+++ b/Tenney/LearnCoordinator.swift
@@ -58,12 +58,14 @@ final class LearnCoordinator: ObservableObject {
         resetBuilderStep4State()
         currentStepIndex -= 1
         enterStep(currentStepIndex)
+        persistState(stepIndex: currentStepIndex, completed: false)
     }
 
     func reset() {
         completed = false
         currentStepIndex = 0
         enterStep(0)
+        persistState(stepIndex: 0, completed: false)
     }
 
 
@@ -98,10 +100,16 @@ final class LearnCoordinator: ObservableObject {
         if next < steps.count {
             currentStepIndex = next
             gate = steps[next].gate
+            persistState(stepIndex: next, completed: false)
         } else {
             completed = true
             gate = LearnGate() // unlock everything
+            persistState(stepIndex: steps.count, completed: true)
         }
+    }
+
+    private func persistState(stepIndex: Int, completed: Bool) {
+        LearnTenneyPersistence.shared.saveState(module, stepIndex: stepIndex, completed: completed)
     }
 
     private func handleBuilderStep4Event(_ event: LearnEvent) {

--- a/Tenney/LearnOverlay.swift
+++ b/Tenney/LearnOverlay.swift
@@ -9,8 +9,12 @@
 //  LearnOverlay.swift
 //  Tenney
 import SwiftUI
+#if os(iOS)
+import UIKit
+#endif
 
 struct LearnOverlay: View {
+    let module: LearnTenneyModule?
     let stepIndex: Int
     let totalSteps: Int
     let step: LearnStep?
@@ -20,10 +24,12 @@ struct LearnOverlay: View {
     let onNext: () -> Void
     let onReset: () -> Void
     let onDone: () -> Void
+    let onContinue: () -> Void
     let nextEnabled: Bool
 
     // Back-compat init (old callers)
     init(currentStep: Int, completed: Bool) {
+        self.module = nil
         self.stepIndex = currentStep
         self.totalSteps = 0
         self.step = nil
@@ -32,10 +38,12 @@ struct LearnOverlay: View {
         self.onNext = {}
         self.onReset = {}
         self.onDone = {}
+        self.onContinue = {}
         self.nextEnabled = true
     }
 
     init(
+        module: LearnTenneyModule? = nil,
         stepIndex: Int,
         totalSteps: Int,
         step: LearnStep?,
@@ -44,8 +52,10 @@ struct LearnOverlay: View {
         onBack: @escaping () -> Void,
         onNext: @escaping () -> Void,
         onReset: @escaping () -> Void,
-        onDone: @escaping () -> Void
+        onDone: @escaping () -> Void,
+        onContinue: @escaping () -> Void = {}
     ) {
+        self.module = module
         self.stepIndex = stepIndex
         self.totalSteps = totalSteps
         self.step = step
@@ -54,101 +64,35 @@ struct LearnOverlay: View {
         self.onNext = onNext
         self.onReset = onReset
         self.onDone = onDone
+        self.onContinue = onContinue
         self.nextEnabled = nextEnabled
     }
 
     var body: some View {
-        VStack(spacing: 10) {
-            if completed {
-                HStack(spacing: 10) {
-                    Text("🎉 Practice Complete")
-                        .font(.subheadline.weight(.semibold))
-                    Spacer()
-                    Button("Done", action: onDone)
-                        .buttonStyle(.borderedProminent)
-                }
+        Group {
+            if completed, let module {
+                LearnCompletionView(
+                    module: module,
+                    onPracticeAgain: onReset,
+                    onDone: onDone,
+                    onContinue: onContinue
+                )
             } else {
                 // Header
-                HStack(spacing: 10) {
-                    Text(titleText)
-                        .font(.subheadline.weight(.semibold))
-                        .lineLimit(1)
-
-                    Spacer()
-
-                    Text(counterText)
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
-                        .background(.thinMaterial, in: Capsule())
-                }
-
-                // Bullets / instruction
-                if !bulletLines.isEmpty {
-                    VStack(alignment: .leading, spacing: 6) {
-                        ForEach(bulletLines, id: \.self) { b in
-                            HStack(alignment: .top, spacing: 8) {
-                                Text("•").foregroundStyle(.secondary)
-                                Text(b).fixedSize(horizontal: false, vertical: true)
-                            }
-                            .font(.subheadline)
-                        }
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                }
-
-                // Try it
-                if let s = step, !s.tryIt.isEmpty {
-                    Divider().opacity(0.7)
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Try it")
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                        Text(s.tryIt)
-                            .font(.subheadline.weight(.semibold))
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                }
-
-                // Controls
-                HStack(spacing: 10) {
-                    Button("Back", action: onBack)
-                        .buttonStyle(.bordered)
-                        .disabled(stepIndex == 0)
-
-                    Button("Reset", action: onReset)
-                        .buttonStyle(.bordered)
-
-                    Spacer()
-
-                    Button(isLastStep ? "Finish" : "Next", action: onNext)
-                        .buttonStyle(.borderedProminent)
-                        .disabled(!nextEnabled)
-                        .opacity(nextEnabled ? 1 : 0.55)
-                }
+                LearnOverlayCardContent(
+                    titleText: titleText,
+                    counterText: counterText,
+                    bulletLines: bulletLines,
+                    step: step,
+                    stepIndex: stepIndex,
+                    isLastStep: isLastStep,
+                    nextEnabled: nextEnabled,
+                    onBack: onBack,
+                    onReset: onReset,
+                    onNext: onNext
+                )
             }
         }
-        .padding(12)
-        .background(
-            Group {
-                if #available(iOS 26.0, *) {
-                    RoundedRectangle(cornerRadius: 18, style: .continuous)
-                        .fill(.clear)
-                        .glassEffect(.regular, in: .rect(cornerRadius: 18))
-                } else {
-                    RoundedRectangle(cornerRadius: 18, style: .continuous)
-                        .fill(.ultraThinMaterial)
-                }
-            }
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .strokeBorder(.white.opacity(0.08), lineWidth: 1)
-        )
-        .accessibilityElement(children: .contain)
-
     }
 
     private var titleText: String {
@@ -172,6 +116,350 @@ struct LearnOverlay: View {
         totalSteps > 0 && stepIndex >= (totalSteps - 1)
     }
 }
+
+private struct LearnOverlayCardContent: View {
+    let titleText: String
+    let counterText: String
+    let bulletLines: [String]
+    let step: LearnStep?
+    let stepIndex: Int
+    let isLastStep: Bool
+    let nextEnabled: Bool
+    let onBack: () -> Void
+    let onReset: () -> Void
+    let onNext: () -> Void
+
+    var body: some View {
+        VStack(spacing: 10) {
+            HStack(spacing: 10) {
+                Text(titleText)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(1)
+
+                Spacer()
+
+                Text(counterText)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(.thinMaterial, in: Capsule())
+            }
+
+            if !bulletLines.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(bulletLines, id: \.self) { b in
+                        HStack(alignment: .top, spacing: 8) {
+                            Text("•").foregroundStyle(.secondary)
+                            Text(b).fixedSize(horizontal: false, vertical: true)
+                        }
+                        .font(.subheadline)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            if let s = step, !s.tryIt.isEmpty {
+                Divider().opacity(0.7)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Try it")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Text(s.tryIt)
+                        .font(.subheadline.weight(.semibold))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            HStack(spacing: 10) {
+                Button("Back", action: onBack)
+                    .buttonStyle(.bordered)
+                    .disabled(stepIndex == 0)
+
+                Button("Reset", action: onReset)
+                    .buttonStyle(.bordered)
+
+                Spacer()
+
+                Button(isLastStep ? "Finish" : "Next", action: onNext)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!nextEnabled)
+                    .opacity(nextEnabled ? 1 : 0.55)
+            }
+        }
+        .padding(12)
+        .background(
+            Group {
+                if #available(iOS 26.0, *) {
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .fill(.clear)
+                        .glassEffect(.regular, in: .rect(cornerRadius: 18))
+                } else {
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .fill(.ultraThinMaterial)
+                }
+            }
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .strokeBorder(.white.opacity(0.08), lineWidth: 1)
+        )
+        .accessibilityElement(children: .contain)
+    }
+}
+
+private struct LearnCompletionView: View {
+    let module: LearnTenneyModule
+    let onPracticeAgain: () -> Void
+    let onDone: () -> Void
+    let onContinue: () -> Void
+
+    @StateObject private var store = LearnTenneyStateStore.shared
+    @State private var didHaptic = false
+    @State private var animateIn = false
+    @State private var sweep = false
+
+    @Environment(\.tenneyTheme) private var theme
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    var body: some View {
+        ZStack {
+            TenneySceneBackground(
+                isDark: colorScheme == .dark,
+                preset: theme.sceneBackgroundPreset,
+                tintA: theme.primeTint(3),
+                tintB: theme.primeTint(5)
+            )
+            .overlay(vignetteOverlay)
+            .ignoresSafeArea()
+
+            ScrollView {
+                VStack(spacing: 18) {
+                    heroPuck
+                        .scaleEffect(animateIn ? 1.0 : (reduceMotion ? 1.0 : 0.92))
+                        .opacity(animateIn ? 1.0 : (reduceMotion ? 1.0 : 0.0))
+
+                    VStack(spacing: 6) {
+                        Text("Module complete")
+                            .font(.title2.weight(.semibold))
+                        Text(subtitle)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                    .multilineTextAlignment(.center)
+                    .scaleEffect(animateIn ? 1.0 : (reduceMotion ? 1.0 : 0.96))
+                    .opacity(animateIn ? 1.0 : (reduceMotion ? 1.0 : 0.0))
+
+                    bulletsView
+
+                    actionCard
+
+                    progressView
+                }
+                .frame(maxWidth: 520)
+                .padding(.horizontal, 22)
+                .padding(.top, 32)
+                .padding(.bottom, 28)
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .onAppear {
+            if !didHaptic {
+#if os(iOS)
+                UINotificationFeedbackGenerator().notificationOccurred(.success)
+#endif
+                didHaptic = true
+            }
+            if reduceMotion {
+                animateIn = true
+            } else {
+                withAnimation(.easeOut(duration: 0.28)) {
+                    animateIn = true
+                }
+                withAnimation(.easeOut(duration: 0.34)) {
+                    sweep = true
+                }
+            }
+        }
+    }
+
+    private var tint: Color {
+        theme.primeTint(3)._tenneyInterpolate(to: theme.primeTint(5), t: 0.5)
+    }
+
+    private var subtitle: String {
+        switch module {
+        case .lattice: return "Lattice is ready."
+        case .tuner: return "Tuner is ready."
+        case .builder: return "Builder is ready."
+        }
+    }
+
+    private var bullets: [String] {
+        switch module {
+        case .lattice:
+            return ["Select ratios", "Audition quickly", "Use prime limits"]
+        case .tuner:
+            return ["Switch views", "Use lock", "Use stage mode"]
+        case .builder:
+            return ["Play pads", "Add root", "Hear blends"]
+        }
+    }
+
+    private var hasNextModule: Bool {
+        module.nextModule != nil
+    }
+
+    private var completedCount: Int {
+        LearnTenneyModule.allCases.filter { store.states[$0]?.completed == true }.count
+    }
+
+    private var totalModules: Int {
+        LearnTenneyModule.allCases.count
+    }
+
+    private var heroPuck: some View {
+        let tintOpacity = colorScheme == .dark ? 0.30 : 0.22
+
+        return ZStack {
+            Circle()
+                .fill(reduceTransparency ? tint.opacity(tintOpacity) : .ultraThinMaterial)
+                .overlay(
+                    Circle()
+                        .fill(tint.opacity(tintOpacity))
+                )
+                .overlay(puckSweep)
+
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 46, weight: .semibold))
+                .foregroundStyle(tint)
+                .shadow(color: tint.opacity(0.25), radius: 6, x: 0, y: 4)
+        }
+        .frame(width: 92, height: 92)
+        .overlay(
+            Circle()
+                .strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
+        )
+    }
+
+    private var puckSweep: some View {
+        Group {
+            if !reduceMotion {
+                GeometryReader { proxy in
+                    let width = proxy.size.width
+                    LinearGradient(
+                        colors: [
+                            Color.white.opacity(0.0),
+                            Color.white.opacity(0.45),
+                            Color.white.opacity(0.0)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                    .rotationEffect(.degrees(-20))
+                    .offset(x: sweep ? width * 0.8 : -width * 0.8)
+                }
+                .mask(Circle())
+                .opacity(0.5)
+            }
+        }
+    }
+
+    private var bulletsView: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(bullets, id: \.self) { bullet in
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Circle()
+                        .fill(tint.opacity(0.5))
+                        .frame(width: 5, height: 5)
+                    Text(bullet)
+                        .font(.subheadline)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(cardBackground, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
+        )
+    }
+
+    private var actionCard: some View {
+        VStack(spacing: 10) {
+            if hasNextModule {
+                Button("Continue to next module", action: onContinue)
+                    .buttonStyle(.borderedProminent)
+            }
+            Button("Practice again", action: onPracticeAgain)
+                .buttonStyle(.bordered)
+
+            Button("Done", action: onDone)
+                .buttonStyle(.plain)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 14)
+        .background(cardBackground, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
+        )
+    }
+
+    private var progressView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("\(completedCount) of \(totalModules) modules completed")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            GeometryReader { proxy in
+                let width = proxy.size.width
+                let progress = totalModules > 0 ? Double(completedCount) / Double(totalModules) : 0
+                Capsule()
+                    .fill(tint.opacity(0.14))
+                    .overlay(alignment: .leading) {
+                        Capsule()
+                            .fill(tint.opacity(0.65))
+                            .frame(width: width * progress)
+                    }
+            }
+            .frame(height: 6)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 6)
+    }
+
+    private var cardBackground: AnyShapeStyle {
+        AnyShapeStyle(reduceTransparency ? Color(uiColor: .systemBackground).opacity(0.92) : .ultraThinMaterial)
+    }
+
+    private var vignetteOverlay: some View {
+        RadialGradient(
+            gradient: Gradient(colors: [
+                Color.clear,
+                Color.black.opacity(colorScheme == .dark ? 0.55 : 0.12)
+            ]),
+            center: .center,
+            startRadius: 60,
+            endRadius: 460
+        )
+        .opacity(reduceTransparency ? 0.35 : 0.6)
+    }
+}
+
+// Manual test checklist:
+// - Complete a module: full-screen completion view + single haptic.
+// - Reduce Motion on: no sweep, no animated scale.
+// - Practice again: resets progress and restarts practice.
+// - Done / Continue to next module: returns to hub.
 
 
 

--- a/Tenney/LearnTenneyHubView.swift
+++ b/Tenney/LearnTenneyHubView.swift
@@ -40,21 +40,35 @@ enum LearnTenneyModule: String, CaseIterable, Identifiable, Sendable {
         case .builder: return "pianokeys.inverse"
         }
     }
+
+    var nextModule: LearnTenneyModule? {
+        let modules = LearnTenneyModule.allCases
+        guard let idx = modules.firstIndex(of: self) else { return nil }
+        let nextIdx = modules.index(after: idx)
+        return nextIdx < modules.endIndex ? modules[nextIdx] : nil
+    }
 }
 
 
 struct LearnTenneyHubView: View {
     let entryPoint: LearnTenneyEntryPoint
 
-    @AppStorage(SettingsKeys.learnLatticeTourCompleted) private var latticeDone: Bool = false
-    @AppStorage(SettingsKeys.learnTunerTourCompleted) private var tunerDone: Bool = false
-    @AppStorage(SettingsKeys.learnBuilderTourCompleted) private var builderDone: Bool = false
+    @StateObject private var store = LearnTenneyStateStore.shared
+    @State private var activeModule: LearnTenneyModule? = nil
+    @Environment(\.tenneyTheme) private var theme
+    @Environment(\.horizontalSizeClass) private var sizeClass
 
     var body: some View {
         List {
             Section {
                 ForEach(LearnTenneyModule.allCases) { m in
-                    NavigationLink {
+                    let state = stateForModule(m)
+                    let totalSteps = LearnStepFactory.steps(for: m).count
+                    let stepsDone = min(max(0, state.stepIndex), totalSteps)
+                    let progress = totalSteps > 0 ? Double(stepsDone) / Double(totalSteps) : 0
+                    let tint = moduleTint
+
+                    NavigationLink(tag: m, selection: $activeModule) {
                         LearnTenneyModuleView(module: m)
                     } label: {
                         HStack(spacing: 12) {
@@ -65,8 +79,18 @@ struct LearnTenneyHubView: View {
                                 .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
 
                             VStack(alignment: .leading, spacing: 2) {
-                                Text(m.title)
-                                    .font(.headline)
+                                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                                    Text(m.title)
+                                        .font(.headline)
+
+                                    LearnModuleBadge(
+                                        state: state,
+                                        progress: progress,
+                                        tint: tint,
+                                        size: sizeClass == .regular ? 16 : 14
+                                    )
+                                    .alignmentGuide(.firstTextBaseline) { d in d[.bottom] }
+                                }
                                 Text(m.subtitle)
                                     .font(.subheadline)
                                     .foregroundStyle(.secondary)
@@ -74,14 +98,19 @@ struct LearnTenneyHubView: View {
                             }
 
                             Spacer()
-
-                            if isCompleted(m) {
-                                Image(systemName: "checkmark.seal.fill")
-                                    .foregroundStyle(.green)
-                                    .accessibilityLabel("Tour completed")
-                            }
                         }
                         .padding(.vertical, 2)
+                        .overlay(alignment: .leading) {
+                            if state.completed {
+                                RoundedRectangle(cornerRadius: 1, style: .continuous)
+                                    .fill(tint.opacity(0.7))
+                                    .frame(width: 3)
+                                    .padding(.vertical, 6)
+                            }
+                        }
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel(Text(m.title))
+                        .accessibilityValue(Text(accessibilityValue(for: m, state: state, totalSteps: totalSteps)))
                     }
                 }
             } header: {
@@ -92,13 +121,95 @@ struct LearnTenneyHubView: View {
         }
         .navigationTitle("Learn Tenney")
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            if let pending = store.pendingModuleToOpen {
+                activeModule = pending
+                store.pendingModuleToOpen = nil
+            }
+        }
+        .onChange(of: store.pendingModuleToOpen) { pending in
+            guard let pending else { return }
+            activeModule = pending
+            store.pendingModuleToOpen = nil
+        }
     }
 
-    private func isCompleted(_ m: LearnTenneyModule) -> Bool {
-        switch m {
-        case .lattice: return latticeDone
-        case .tuner:   return tunerDone
-        case .builder: return builderDone
+    private var moduleTint: Color {
+        theme.primeTint(3)._tenneyInterpolate(to: theme.primeTint(5), t: 0.5)
+    }
+
+    private func stateForModule(_ m: LearnTenneyModule) -> TenneyPracticeSnapshot.ModuleState {
+        store.states[m] ?? .init(stepIndex: 0, completed: false)
+    }
+
+    private func accessibilityValue(for module: LearnTenneyModule, state: TenneyPracticeSnapshot.ModuleState, totalSteps: Int) -> String {
+        if state.completed {
+            return "Completed."
         }
+        if state.stepIndex > 0, totalSteps > 0 {
+            let stepNumber = min(state.stepIndex + 1, totalSteps)
+            return "In progress, step \(stepNumber) of \(totalSteps)."
+        }
+        return "Not started."
+    }
+}
+
+private struct LearnModuleBadge: View {
+    let state: TenneyPracticeSnapshot.ModuleState
+    let progress: Double
+    let tint: Color
+    let size: CGFloat
+
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    private var isInProgress: Bool {
+        state.stepIndex > 0 && !state.completed
+    }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .strokeBorder(Color.secondary.opacity(0.25), lineWidth: 2)
+
+            if isInProgress {
+                Circle()
+                    .trim(from: 0, to: min(max(progress, 0), 0.98))
+                    .stroke(tint, style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+            }
+
+            if state.completed {
+                Circle()
+                    .strokeBorder(tint, lineWidth: 2.2)
+                    .shadow(color: tint.opacity(0.35), radius: 3, x: 0, y: 0)
+            }
+
+            Circle()
+                .fill(innerFill)
+
+            if state.completed {
+                Circle()
+                    .fill(Color.white.opacity(0.35))
+                    .frame(width: size * 0.22, height: size * 0.22)
+                    .offset(x: -size * 0.18, y: -size * 0.18)
+
+                Image(systemName: "checkmark")
+                    .font(.system(size: size * 0.55, weight: .bold))
+                    .foregroundStyle(Color.primary)
+                    .shadow(color: Color.black.opacity(0.25), radius: 1, x: 0, y: 0.5)
+            }
+        }
+        .frame(width: size, height: size)
+        .accessibilityHidden(true)
+    }
+
+    private var innerFill: Color {
+        if state.completed {
+            return tint.opacity(0.22)
+        }
+        if isInProgress {
+            return tint.opacity(0.12)
+        }
+        return reduceTransparency ? Color.secondary.opacity(0.05) : Color.clear
     }
 }


### PR DESCRIPTION
### Motivation
- Replace the existing minimal “Practice Complete” stub with a high-quality, Apple-HIG–grade completion experience that fits the Learn overlay system and theme tokens. 
- Surface per-module progress and completion in the hub with a compact, accessible badge so users can scan not-started / in-progress / completed states reliably. 
- Keep persistence single-sourced and wire the coordinator to update progress so the hub updates live without polling.

### Description
- Implemented a full-screen completion view inside the existing overlay system as `LearnCompletionView` (hero puck with `checkmark.circle.fill`, subtitle, 2–3 bullets, action card, and bottom progress cue) and wired it into `LearnOverlay` so it appears only when the coordinator `completed` is true and the module is available; respects `Reduce Motion` and `Reduce Transparency`, and fires a single success haptic on iOS via `UINotificationFeedbackGenerator()` (guarded to happen once with `@State didHaptic`).
- Added module progress persistence and an observable state store: `TenneyPracticeSnapshot.ModuleState` and `LearnTenneyStateStore.shared` with `states` and one-shot `pendingModuleToOpen`, and new `saveState` / `loadState` / `resetState` helpers in `TenneyPracticeSnapshot` to centralize reads/writes and notify the shared store.
- Wired coordinator and practice flows to persist progress: `LearnCoordinator` now calls `persistState(stepIndex:completed:)` on `advance`, `back` and `reset`; `LearnTenneyPracticeView` adds `resetPractice()` to restart practice (resets coordinator, persisted state and ephemeral flags) and `continueToNextModule()` that sets `LearnTenneyStateStore.shared.pendingModuleToOpen` as a safe fallback to open the next module from the hub.
- Replaced the hub checkmark with a compact badge `LearnModuleBadge` showing not-started / in-progress (trimmed arc) / completed (full ring + tiny check), baseline-aligned to the row title, with accessibility label/value strings and optional leading tint stripe for completed rows; progress is computed from persisted `stepIndex` and `LearnStepFactory.steps(for:)` total.

Files changed (high level): `Tenney/LearnOverlay.swift`, `Tenney/LearnTenneyPersistence.swift`, `Tenney/LearnTenneyHubView.swift`, `Tenney/LearnCoordinator.swift`, `Tenney/LearnTenneyPractice.swift`.

### Testing
- Automated tests: none run in this PR (no CI/unit tests were executed as part of the change). 
- A manual test checklist was included in `LearnOverlay.swift` as comments and should be exercised during QA: complete a module to verify full-screen completion and single haptic, verify `Reduce Motion` removes sweep/scale animations, tap `Practice again` to verify reset, tap `Done` to return to hub, confirm hub badges reflect not-started / in-progress / completed and that the X of Y progress rail is correct.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972d191205c8327be9b3dd50c537a97)