### PR TITLE
Make iPad/Mac sheets use shared large sizing

### DIFF
--- a/Tenney/CommunityPacksViews.swift
+++ b/Tenney/CommunityPacksViews.swift
@@ -375,6 +375,7 @@ struct CommunityPacksPageList: View {
             .presentationDetents([.large])
             .presentationDragIndicator(.hidden)
             .presentationBackground(PremiumModalSurface.background)
+            .tenneySheetSizing()
         }
         .task {
             guard !didTriggerRefresh else { return }

--- a/Tenney/ContentView.swift
+++ b/Tenney/ContentView.swift
@@ -283,6 +283,7 @@ private let libraryStore = ScaleLibraryStore.shared
             .presentationDetents([.medium, .large])
             .presentationDragIndicator(.visible)
             .presentationBackground(.ultraThinMaterial)
+            .tenneySheetSizing()
         }
 
         .onReceive(NotificationCenter.default.publisher(for: .venueCalibrated)) { note in
@@ -548,6 +549,7 @@ private let libraryStore = ScaleLibraryStore.shared
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
                 .presentationBackground(.ultraThinMaterial)
+                .tenneySheetSizing()
         }
     }
 
@@ -601,6 +603,7 @@ private let libraryStore = ScaleLibraryStore.shared
             .onDisappear {
                 requestedSettingsCategory = nil
             }
+            .tenneySheetSizing()
     }
 
     private var scaleLibraryDetent: some View {
@@ -610,6 +613,7 @@ private let libraryStore = ScaleLibraryStore.shared
             .presentationDragIndicator(.visible)
             .presentationBackground(.ultraThinMaterial)
             .onAppear { app.setMicActive(false) }
+            .tenneySheetSizing()
     }
     private var rootStudioDetent: some View {
         RootStudioSheet(tab: $rootStudioTab, ns: rootNS)
@@ -617,6 +621,7 @@ private let libraryStore = ScaleLibraryStore.shared
             .presentationDetents([.medium, .large])
             .presentationDragIndicator(.visible)
             .presentationBackground(.ultraThinMaterial)
+            .tenneySheetSizing()
     }
 
 #if targetEnvironment(macCatalyst)

--- a/Tenney/LatticeView.swift
+++ b/Tenney/LatticeView.swift
@@ -2199,6 +2199,7 @@ struct LatticeView: View {
                 .presentationDetents([.height(300), .large])
                 .presentationDragIndicator(.hidden) // we provide our own (matched-geometry) handle
                 .presentationBackground(.ultraThinMaterial)
+                .tenneySheetSizing()
             }
         }
         

--- a/Tenney/ScaleBuilderScreen.swift
+++ b/Tenney/ScaleBuilderScreen.swift
@@ -371,6 +371,7 @@ struct ScaleBuilderScreen: View {
                     // Optional: play ascending scale quickly (non-blocking)
                     playScalePreview(scale)
                 }
+                .tenneySheetSizing()
             }
             .onChange(of: store.degrees) { _ in
                 // Any structural change (including Clear) → silence and reset offsets
@@ -529,6 +530,7 @@ struct ScaleBuilderScreen: View {
                 }
             }) {
                 ActivityView(activityItems: exportURLs)
+                    .tenneySheetSizing()
             }
 
             

--- a/Tenney/ScaleLibrarySheet.swift
+++ b/Tenney/ScaleLibrarySheet.swift
@@ -247,6 +247,7 @@ struct ScaleLibrarySheet: View {
                 )
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
+                .tenneySheetSizing()
             }
             .sheet(isPresented: $showFilterSheet) {
                 LibraryFilterSheet(
@@ -256,6 +257,7 @@ struct ScaleLibrarySheet: View {
                     onDone: { showFilterSheet = false }
                 )
                 .presentationDetents([.medium, .large])
+                .tenneySheetSizing()
             }
         }
         .overlay(alignment: .topTrailing) {
@@ -1291,9 +1293,11 @@ struct ScaleActionsSheet: View {
                 .padding(.bottom, 24)
             }
             .presentationDetents([.medium, .large])
+            .tenneySheetSizing()
         }
         .sheet(isPresented: $isPresentingShareSheet) {
             ActivityView(activityItems: exportURLs)
+                .tenneySheetSizing()
         }
 
         .sheet(isPresented: $showTagsSheet) {
@@ -1315,6 +1319,7 @@ struct ScaleActionsSheet: View {
             .presentationDetents([.medium, .large], selection: $tagsDetent)
             .presentationDragIndicator(tagsEditorPresented ? .hidden : .hidden)
             .interactiveDismissDisabled(tagsEditorPresented)
+            .tenneySheetSizing()
         }
         .onChange(of: playbackMode) { newMode in
             if newMode == .drone {

--- a/Tenney/Settings.swift
+++ b/Tenney/Settings.swift
@@ -822,6 +822,7 @@ struct StudioConsoleView: View {
                         }
                     }
                     .presentationDetents([.medium, .large])
+                    .tenneySheetSizing()
                 }
 
                 Text("Presets store enabled cards and order. Collapse state and rail width are per-window.")
@@ -2789,6 +2790,7 @@ struct StudioConsoleView: View {
                     markWhatsNewSeen()
                 }
             )
+            .tenneySheetSizing()
         }
         .background(
             SettingsChangeSinks(
@@ -2901,6 +2903,7 @@ struct StudioConsoleView: View {
                 NavigationStack {
                     HejiGalleryView()
                 }
+                .tenneySheetSizing()
             }
 #endif
 

--- a/Tenney/TenneySheetSizing.swift
+++ b/Tenney/TenneySheetSizing.swift
@@ -1,0 +1,56 @@
+//
+//  TenneySheetSizing.swift
+//  Tenney
+//
+//  Created by OpenAI on 3/5/25.
+//
+
+import SwiftUI
+import UIKit
+
+private struct TenneySheetSizing: ViewModifier {
+    private var shouldApplySizing: Bool {
+#if targetEnvironment(macCatalyst)
+        return true
+#else
+        return UIDevice.current.userInterfaceIdiom != .phone
+#endif
+    }
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if shouldApplySizing {
+            if #available(iOS 16.0, *) {
+                content
+                    .presentationDetents([.large])
+                    .presentationDragIndicator(.visible)
+                    .frame(
+                        minWidth: 700,
+                        idealWidth: 860,
+                        maxWidth: .infinity,
+                        minHeight: 720,
+                        idealHeight: 900,
+                        maxHeight: .infinity
+                    )
+            } else {
+                content
+                    .frame(
+                        minWidth: 700,
+                        idealWidth: 860,
+                        maxWidth: .infinity,
+                        minHeight: 720,
+                        idealHeight: 900,
+                        maxHeight: .infinity
+                    )
+            }
+        } else {
+            content
+        }
+    }
+}
+
+extension View {
+    func tenneySheetSizing() -> some View {
+        modifier(TenneySheetSizing())
+    }
+}

--- a/Tenney/ThemeStudioView.swift
+++ b/Tenney/ThemeStudioView.swift
@@ -301,6 +301,7 @@ var body: some View {
             }
         )
         .presentationDetents([.medium, .large])
+        .tenneySheetSizing()
     }
     .onChange(of: focus) { newFocus in
         // Commit on focus loss (identity only)


### PR DESCRIPTION
### Motivation
- Sheets on iPad and Mac Catalyst felt too small and centered, so make them intentionally large and readable while preserving iPhone behavior.
- Use a single reusable helper to apply consistent detents, drag indicator and sizing across the app to minimize regressions and duplication.
- Avoid introducing nested sheet presentations; keep Learn Tenney presented via navigation where appropriate.

### Description
- Add `TenneySheetSizing.swift` implementing `View.tenneySheetSizing()` as a reusable `ViewModifier` that gates sizing to Mac Catalyst and non-phone idioms and uses availability checks for `presentationDetents` when available.
- The modifier applies `.presentationDetents([.large])`, `.presentationDragIndicator(.visible)`, and `frame(minWidth:700, idealWidth:860, maxWidth:.infinity, minHeight:720, idealHeight:900, maxHeight:.infinity)` for larger displays.
- Apply `.tenneySheetSizing()` to sheet contents across the app, including `ContentView` (Settings, builder, library, root studio, What's New), `Settings` (various sheets), `ScaleLibrarySheet`, `ScaleBuilderScreen`, `ThemeStudioView`, `LatticeView`, and `CommunityPacksViews` to standardize sizing.
- Keep all changes minimal and availability-gated so phone behavior is unchanged and nested-sheet presentation was not introduced.

### Testing
- No automated tests were run as part of this change.
- Manual verification on an iPad/Catalyst simulator is still recommended to confirm the visual sizing and dismissal behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972d7f0dc3c83278df5747bd95e6eb1)