### PR TITLE
Add Color‑blind Assist (shapes + optional patterns) with settings, theme token, and lightweight shape system

### DIFF
--- a/Tenney/ContentView.swift
+++ b/Tenney/ContentView.swift
@@ -997,10 +997,18 @@ extension Notification.Name {
                         // tiny prime badge guesses from label (fast path; you already have NotationFormatter if needed)
                         let primes = label.split(separator: "/").flatMap { Int($0) }.flatMap { factors($0) }.filter { $0 > 2 }
                         HStack(spacing: 6) {
-                                                    ForEach(Array(Set(primes)).sorted(), id: \.self) { p in
-                                                        BadgeCapsule(text: "\(p)", style: AnyShapeStyle(theme.primeTint(p)))
-                                                    }
-                                                }
+                            ForEach(Array(Set(primes)).sorted(), id: \.self) { p in
+                                if theme.accessibilityEncoding.enabled {
+                                    TenneyPrimeLimitBadge(
+                                        prime: p,
+                                        tint: theme.primeTint(p),
+                                        encoding: theme.accessibilityEncoding
+                                    )
+                                } else {
+                                    BadgeCapsule(text: "\(p)", style: AnyShapeStyle(theme.primeTint(p)))
+                                }
+                            }
+                        }
                         Spacer()
                     }
 
@@ -1077,34 +1085,45 @@ extension Notification.Name {
                     Text("Limit").font(.caption).foregroundStyle(.secondary)
                     ForEach([3,5,7,11,13], id:\.self) { p in
                         let selected = (store.primeLimit == p)
-                        Button {
-                            withAnimation(.snappy) { store.primeLimit = p }
-                        } label: {
-                            Text("\(p)")
-                                .font(.footnote.weight(selected ? .semibold : .regular))
-                                .foregroundStyle(
-                                    selected
-                                    ? (theme.isDark ? Color.white : Color.black)
-                                    : Color.secondary
-                                )
-                                .padding(.horizontal, 10)
-                                .padding(.vertical, 6)
-                                .background(
-                                    selected
-                                    ? AnyShapeStyle(.thinMaterial)
-                                    : AnyShapeStyle(.ultraThinMaterial),
-                                    in: Capsule()
-                                )
-                                .overlay(
-                                    Capsule().stroke(
+                        if theme.accessibilityEncoding.enabled {
+                            TenneyPrimeLimitChip(
+                                prime: p,
+                                isOn: selected,
+                                tint: theme.primeTint(p),
+                                encoding: theme.accessibilityEncoding
+                            ) {
+                                withAnimation(.snappy) { store.primeLimit = p }
+                            }
+                        } else {
+                            Button {
+                                withAnimation(.snappy) { store.primeLimit = p }
+                            } label: {
+                                Text("\(p)")
+                                    .font(.footnote.weight(selected ? .semibold : .regular))
+                                    .foregroundStyle(
                                         selected
-                                        ? AnyShapeStyle(theme.primeTint(p))
-                                        : AnyShapeStyle(Color.secondary.opacity(0.12)),
-                                        lineWidth: 1
+                                        ? (theme.isDark ? Color.white : Color.black)
+                                        : Color.secondary
                                     )
-                                )
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 6)
+                                    .background(
+                                        selected
+                                        ? AnyShapeStyle(.thinMaterial)
+                                        : AnyShapeStyle(.ultraThinMaterial),
+                                        in: Capsule()
+                                    )
+                                    .overlay(
+                                        Capsule().stroke(
+                                            selected
+                                            ? AnyShapeStyle(theme.primeTint(p))
+                                            : AnyShapeStyle(Color.secondary.opacity(0.12)),
+                                            lineWidth: 1
+                                        )
+                                    )
+                            }
+                            .buttonStyle(.plain)
                         }
-                        .buttonStyle(.plain)
                     }
                     Spacer()
                 }
@@ -1217,23 +1236,34 @@ extension Notification.Name {
                                 Text("Limit").font(.caption).foregroundStyle(.secondary)
                                 ForEach([3,5,7,11,13], id:\.self) { p in
                                     let selected = (store.primeLimit == p)
-                                    Button {
-                                        withAnimation(.snappy) { store.primeLimit = p }
-                                    } label: {
-                                        Text("\(p)")
-                                            .font(.footnote.weight(selected ? .semibold : .regular))
-                                            .foregroundStyle(selected ? (theme.isDark ? .white : .black) : .secondary)
-                                            .padding(.horizontal, 8)
-                                            .padding(.vertical, 5)
-                                            .background(selected ? AnyShapeStyle(.thinMaterial) : AnyShapeStyle(.ultraThinMaterial), in: Capsule())
-                                            .overlay(
-                                                Capsule().stroke(
-                                                    selected ? AnyShapeStyle(theme.primeTint(p)) : AnyShapeStyle(Color.secondary.opacity(0.12)),
-                                                    lineWidth: 1
+                                    if theme.accessibilityEncoding.enabled {
+                                        TenneyPrimeLimitChip(
+                                            prime: p,
+                                            isOn: selected,
+                                            tint: theme.primeTint(p),
+                                            encoding: theme.accessibilityEncoding
+                                        ) {
+                                            withAnimation(.snappy) { store.primeLimit = p }
+                                        }
+                                    } else {
+                                        Button {
+                                            withAnimation(.snappy) { store.primeLimit = p }
+                                        } label: {
+                                            Text("\(p)")
+                                                .font(.footnote.weight(selected ? .semibold : .regular))
+                                                .foregroundStyle(selected ? (theme.isDark ? .white : .black) : .secondary)
+                                                .padding(.horizontal, 8)
+                                                .padding(.vertical, 5)
+                                                .background(selected ? AnyShapeStyle(.thinMaterial) : AnyShapeStyle(.ultraThinMaterial), in: Capsule())
+                                                .overlay(
+                                                    Capsule().stroke(
+                                                        selected ? AnyShapeStyle(theme.primeTint(p)) : AnyShapeStyle(Color.secondary.opacity(0.12)),
+                                                        lineWidth: 1
+                                                    )
                                                 )
-                                            )
+                                        }
+                                        .buttonStyle(.plain)
                                     }
-                                    .buttonStyle(.plain)
                                 }
                                 Spacer(minLength: 0)
                             }

--- a/Tenney/SettingsKeys.swift
+++ b/Tenney/SettingsKeys.swift
@@ -67,6 +67,8 @@ enum SettingsKeys {
     static let tenneyThemeScopeMode   = "tenney.theme.scope.mode"         // String (TenneyScopeColorMode)
     static let tenneyCustomThemes     = "tenney.theme.customThemes"       // Data ([CustomTheme])
     static let tenneyMonochromeTintHex = "tenney.monochromeTintHex"
+    static let tenneyColorBlindModeEnabled = "tenney.a11y.colorBlindModeEnabled"
+    static let tenneyColorBlindModePatternsEnabled = "tenney.a11y.colorBlindModePatternsEnabled"
 
     //scope tuner
     static let tunerScopePartial = "Tenney.Tuner.ScopePartial"

--- a/Tenney/TenneyLimitA11yViews.swift
+++ b/Tenney/TenneyLimitA11yViews.swift
@@ -1,0 +1,145 @@
+//
+//  TenneyLimitA11yViews.swift
+//  Tenney
+//
+
+import SwiftUI
+
+struct TenneyLimitGlyph: View {
+    let bucket: TenneyLimitBucket
+    let fill: Color
+    let stroke: Color
+    let strokeWidth: CGFloat
+    let showPattern: Bool
+
+    var body: some View {
+        LimitShape(bucket: bucket)
+            .fill(fill)
+            .overlay(patternOverlay)
+            .overlay(
+                LimitShape(bucket: bucket)
+                    .stroke(stroke, lineWidth: strokeWidth)
+            )
+            .overlay(innerRingOverlay)
+    }
+
+    @ViewBuilder
+    private var patternOverlay: some View {
+        guard showPattern, let kind = TenneyLimitPattern.kind(for: bucket) else { return }
+
+        switch kind {
+        case .stroke:
+            LimitPatternShape(bucket: bucket)
+                .stroke(stroke.opacity(0.65), lineWidth: max(0.8, strokeWidth * 0.6))
+                .clipShape(LimitShape(bucket: bucket))
+        case .dots:
+            LimitPatternShape(bucket: bucket)
+                .fill(stroke.opacity(0.65))
+                .clipShape(LimitShape(bucket: bucket))
+        }
+    }
+
+    @ViewBuilder
+    private var innerRingOverlay: some View {
+        guard showPattern, bucket.rawValue >= TenneyLimitBucket.limit17.rawValue else { return }
+
+        LimitShape(bucket: bucket)
+            .stroke(stroke.opacity(0.75), lineWidth: max(1.2, strokeWidth))
+            .overlay(
+                LimitShape(bucket: bucket)
+                    .scaleEffect(0.62)
+                    .fill(fill.opacity(0.35))
+            )
+            .clipShape(LimitShape(bucket: bucket))
+    }
+}
+
+private struct LimitPatternShape: Shape {
+    let bucket: TenneyLimitBucket
+
+    func path(in rect: CGRect) -> Path {
+        TenneyLimitPattern.path(bucket: bucket, in: rect) ?? Path()
+    }
+}
+
+struct TenneyPrimeLimitChip: View {
+    let prime: Int
+    let isOn: Bool
+    let tint: Color
+    let encoding: TenneyA11yEncoding
+    let action: () -> Void
+
+    var body: some View {
+        let bucket = bucket(forPrime: prime)
+        let stroke = Color.primary.opacity(encoding.strokeContrast)
+        let fill = isOn ? tint.opacity(0.22) : Color.clear
+        let lineWidth: CGFloat = isOn ? 2.0 : 1.0
+
+        Button(action: action) {
+            HStack(spacing: 6) {
+                TenneyLimitGlyph(
+                    bucket: bucket,
+                    fill: fill,
+                    stroke: stroke,
+                    strokeWidth: lineWidth,
+                    showPattern: isOn && encoding.limitSymbolStyle == .shapeAndHatch
+                )
+                .frame(width: 14, height: 14)
+
+                Text("\(prime)")
+                    .font(.caption2.weight(isOn ? .semibold : .regular))
+
+                if isOn {
+                    Image(systemName: "checkmark")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(stroke)
+                }
+            }
+            .foregroundStyle(isOn ? .primary : .secondary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(isOn ? AnyShapeStyle(.thinMaterial) : AnyShapeStyle(.ultraThinMaterial), in: Capsule())
+            .overlay(
+                Capsule()
+                    .stroke(stroke.opacity(isOn ? 0.75 : 0.35), lineWidth: lineWidth)
+            )
+        }
+        .buttonStyle(.plain)
+        .contentShape(Capsule())
+        .accessibilityLabel("Prime limit \(prime). Shape \(bucket.shapeName). \(isOn ? "Enabled" : "Disabled").")
+        .accessibilityAddTraits(isOn ? .isSelected : [])
+    }
+}
+
+struct TenneyPrimeLimitBadge: View {
+    let prime: Int
+    let tint: Color
+    let encoding: TenneyA11yEncoding
+
+    var body: some View {
+        let bucket = bucket(forPrime: prime)
+        let stroke = Color.primary.opacity(encoding.strokeContrast)
+
+        HStack(spacing: 4) {
+            TenneyLimitGlyph(
+                bucket: bucket,
+                fill: tint.opacity(0.20),
+                stroke: stroke,
+                strokeWidth: 1.2,
+                showPattern: encoding.limitSymbolStyle == .shapeAndHatch
+            )
+            .frame(width: 12, height: 12)
+
+            Text("\(prime)")
+                .font(.caption2.weight(.semibold))
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(.thinMaterial, in: Capsule())
+        .overlay(
+            Capsule()
+                .stroke(stroke.opacity(0.25), lineWidth: 1)
+        )
+        .accessibilityLabel("Prime limit \(prime). Shape \(bucket.shapeName).")
+    }
+}

--- a/Tenney/TenneyLimitEncoding.swift
+++ b/Tenney/TenneyLimitEncoding.swift
@@ -1,0 +1,69 @@
+//
+//  TenneyLimitEncoding.swift
+//  Tenney
+//
+//  Shared helpers for limit buckets + accessibility-friendly labeling.
+//
+
+import Foundation
+
+enum TenneyLimitBucket: Int, CaseIterable, Sendable {
+    case limit5 = 5
+    case limit7 = 7
+    case limit11 = 11
+    case limit13 = 13
+    case limit17 = 17
+    case limit19 = 19
+    case limit23 = 23
+    case limit29 = 29
+    case limit31 = 31
+
+    var shapeName: String {
+        switch self {
+        case .limit5: return "circle"
+        case .limit7: return "triangle"
+        case .limit11: return "square"
+        case .limit13: return "diamond"
+        case .limit17: return "pentagon"
+        case .limit19: return "hexagon"
+        case .limit23: return "heptagon"
+        case .limit29: return "octagon"
+        case .limit31: return "shield"
+        }
+    }
+}
+
+func limitBucket(for signature: RatioSignature) -> TenneyLimitBucket {
+    guard let highest = signature.exps.map(\.p).max() else { return .limit5 }
+    return bucket(forPrime: highest)
+}
+
+func bucket(forPrime p: Int) -> TenneyLimitBucket {
+    switch p {
+    case ..<7:
+        return .limit5
+    case 7:
+        return .limit7
+    case 11:
+        return .limit11
+    case 13:
+        return .limit13
+    case 17:
+        return .limit17
+    case 19:
+        return .limit19
+    case 23:
+        return .limit23
+    case 29:
+        return .limit29
+    default:
+        return .limit31
+    }
+}
+
+// MARK: - Manual QA checklist
+// - Toggle OFF: visuals unchanged.
+// - Toggle ON: lattice nodes, tuner chips, and overlay chips show shapes.
+// - Patterns: only active when enabled, and disabled for Reduce Motion/Transparency.
+// - Light/Dark: shapes + stroke remain readable.
+// - Performance: lattice pan/zoom remains smooth.

--- a/Tenney/TenneyLimitShapes.swift
+++ b/Tenney/TenneyLimitShapes.swift
@@ -1,0 +1,157 @@
+//
+//  TenneyLimitShapes.swift
+//  Tenney
+//
+
+import SwiftUI
+
+struct RegularPolygon: Shape {
+    let sides: Int
+
+    func path(in rect: CGRect) -> Path {
+        guard sides >= 3 else { return Path() }
+
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        let radius = min(rect.width, rect.height) * 0.5
+        let startAngle = -CGFloat.pi / 2
+        let step = (2 * CGFloat.pi) / CGFloat(sides)
+
+        var path = Path()
+        for i in 0..<sides {
+            let angle = startAngle + step * CGFloat(i)
+            let point = CGPoint(
+                x: center.x + radius * cos(angle),
+                y: center.y + radius * sin(angle)
+            )
+            if i == 0 {
+                path.move(to: point)
+            } else {
+                path.addLine(to: point)
+            }
+        }
+        path.closeSubpath()
+        return path
+    }
+}
+
+struct DiamondShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.midX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
+        path.addLine(to: CGPoint(x: rect.midX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.midY))
+        path.closeSubpath()
+        return path
+    }
+}
+
+struct ShieldShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let top = CGPoint(x: rect.midX, y: rect.minY)
+        let leftTop = CGPoint(x: rect.minX + rect.width * 0.12, y: rect.minY + rect.height * 0.20)
+        let rightTop = CGPoint(x: rect.maxX - rect.width * 0.12, y: rect.minY + rect.height * 0.20)
+        let leftMid = CGPoint(x: rect.minX + rect.width * 0.18, y: rect.minY + rect.height * 0.62)
+        let rightMid = CGPoint(x: rect.maxX - rect.width * 0.18, y: rect.minY + rect.height * 0.62)
+        let bottom = CGPoint(x: rect.midX, y: rect.maxY)
+
+        path.move(to: top)
+        path.addLine(to: leftTop)
+        path.addLine(to: leftMid)
+        path.addQuadCurve(to: bottom, control: CGPoint(x: rect.minX + rect.width * 0.5, y: rect.maxY + rect.height * 0.05))
+        path.addQuadCurve(to: rightMid, control: CGPoint(x: rect.maxX - rect.width * 0.5, y: rect.maxY + rect.height * 0.05))
+        path.addLine(to: rightTop)
+        path.closeSubpath()
+        return path
+    }
+}
+
+struct LimitShape: Shape {
+    let bucket: TenneyLimitBucket
+
+    func path(in rect: CGRect) -> Path {
+        switch bucket {
+        case .limit5:
+            return Circle().path(in: rect)
+        case .limit7:
+            return RegularPolygon(sides: 3).path(in: rect)
+        case .limit11:
+            return Rectangle().path(in: rect)
+        case .limit13:
+            return DiamondShape().path(in: rect)
+        case .limit17:
+            return RegularPolygon(sides: 5).path(in: rect)
+        case .limit19:
+            return RegularPolygon(sides: 6).path(in: rect)
+        case .limit23:
+            return RegularPolygon(sides: 7).path(in: rect)
+        case .limit29:
+            return RegularPolygon(sides: 8).path(in: rect)
+        case .limit31:
+            return ShieldShape().path(in: rect)
+        }
+    }
+}
+
+func limitShapePath(bucket: TenneyLimitBucket, in rect: CGRect) -> Path {
+    LimitShape(bucket: bucket).path(in: rect)
+}
+
+enum TenneyLimitPatternKind {
+    case stroke
+    case dots
+}
+
+enum TenneyLimitPattern {
+    private static let unitPaths: [TenneyLimitBucket: Path] = {
+        var paths: [TenneyLimitBucket: Path] = [:]
+
+        // 7: diagonal hatch
+        var hatch = Path()
+        for x in stride(from: -0.4, through: 1.1, by: 0.28) {
+            hatch.move(to: CGPoint(x: x, y: 0))
+            hatch.addLine(to: CGPoint(x: x + 1.0, y: 1.0))
+        }
+        paths[.limit7] = hatch
+
+        // 11: dot stipple
+        var dots = Path()
+        let dotRadius: CGFloat = 0.06
+        for x in stride(from: 0.2, through: 0.8, by: 0.3) {
+            for y in stride(from: 0.2, through: 0.8, by: 0.3) {
+                let rect = CGRect(x: x - dotRadius, y: y - dotRadius, width: dotRadius * 2, height: dotRadius * 2)
+                dots.addEllipse(in: rect)
+            }
+        }
+        paths[.limit11] = dots
+
+        // 13: cross hatch
+        var cross = hatch
+        for x in stride(from: -0.4, through: 1.1, by: 0.28) {
+            cross.move(to: CGPoint(x: x, y: 1.0))
+            cross.addLine(to: CGPoint(x: x + 1.0, y: 0.0))
+        }
+        paths[.limit13] = cross
+
+        return paths
+    }()
+
+    static func kind(for bucket: TenneyLimitBucket) -> TenneyLimitPatternKind? {
+        switch bucket {
+        case .limit7, .limit13:
+            return .stroke
+        case .limit11:
+            return .dots
+        default:
+            return nil
+        }
+    }
+
+    static func path(bucket: TenneyLimitBucket, in rect: CGRect) -> Path? {
+        guard let unit = unitPaths[bucket] else { return nil }
+        let transform = CGAffineTransform(scaleX: rect.width, y: rect.height)
+            .concatenating(CGAffineTransform(translationX: rect.minX, y: rect.minY))
+        return unit.applying(transform)
+    }
+}

--- a/Tenney/TenneyThemeCache.swift
+++ b/Tenney/TenneyThemeCache.swift
@@ -36,6 +36,8 @@ final class TenneyThemeCache {
         let mixBasis: String
         let mixMode: String
         let scopeMode: String
+        let a11yEnabled: Bool
+        let a11yPatternsEnabled: Bool
     }
 
     struct RatioKey: Hashable {

--- a/Tenney/ThemesCenterView.swift
+++ b/Tenney/ThemesCenterView.swift
@@ -23,6 +23,8 @@ struct ThemesCenterView: View {
     @AppStorage(SettingsKeys.tenneyThemeMixBasis) private var mixBasisRaw: String = TenneyMixBasis.complexityWeight.rawValue
     @AppStorage(SettingsKeys.tenneyThemeMixMode) private var mixModeRaw: String = TenneyMixMode.blend.rawValue
     @AppStorage(SettingsKeys.tenneyThemeScopeMode) private var scopeModeRaw: String = TenneyScopeColorMode.constant.rawValue
+    @AppStorage(SettingsKeys.tenneyColorBlindModeEnabled) private var colorBlindAssistEnabled: Bool = false
+    @AppStorage(SettingsKeys.tenneyColorBlindModePatternsEnabled) private var colorBlindPatternsEnabled: Bool = false
 
     private var mixBasis: TenneyMixBasis { TenneyMixBasis(rawValue: mixBasisRaw) ?? .complexityWeight }
     private var mixMode: TenneyMixMode { TenneyMixMode(rawValue: mixModeRaw) ?? .blend }
@@ -332,6 +334,20 @@ struct ThemesCenterView: View {
                         }
 
                         Text("Scope decides what the oscilloscope accent color should follow.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    // Accessibility
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Accessibility").font(.subheadline.weight(.semibold))
+
+                        Toggle("Color-blind Assist (Shapes)", isOn: $colorBlindAssistEnabled)
+                        Toggle("Patterns", isOn: $colorBlindPatternsEnabled)
+                            .disabled(!colorBlindAssistEnabled)
+                            .opacity(colorBlindAssistEnabled ? 1 : 0.55)
+
+                        Text("Adds shape-based cues for prime limits without relying on color.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     }


### PR DESCRIPTION
### Motivation
- Provide a minimal, theme-aware “Color‑blind Assist” mode that does not rely on color alone and leaves default visuals unchanged when off.
- Keep the surface area small and safe for performance-sensitive lattice rendering by adding small shared helpers and localized view changes instead of large refactors.
- Expose user controls to toggle the assist mode and optional patterns while respecting system accessibility settings (Reduce Motion / Reduce Transparency / Increased Contrast).

### Description
- Add two persisted settings keys in `SettingsKeys.swift`: `tenneyColorBlindModeEnabled` and `tenneyColorBlindModePatternsEnabled`, exposed in Themes → Advanced → Accessibility as toggles labeled “Color‑blind Assist (Shapes)” and “Patterns” (Patterns is disabled unless the first toggle is ON). (`Tenney/ThemesCenterView.swift`)
- Introduce a compact theme token `TenneyA11yEncoding` and enum `TenneyLimitSymbolStyle` on the resolved theme surface (`Tenney/TenneyTheme.swift`), with a scheme-aware `resolved(...)` helper that respects system accessibility flags and the two AppStorage toggles.
- Wire `accessibilityEncoding` into theme resolution in `TenneyThemeRegistry.resolvedCurrent` / `resolvedBuiltin` / `resolvedCustom`, caching keys extended to account for assist settings (`Tenney/TenneyThemeRegistry.swift`, `Tenney/TenneyThemeCache.swift`).
- Add a cheap, shared limit classifier and helpers in `Tenney/TenneyLimitEncoding.swift` including `TenneyLimitBucket` and `bucket(forPrime:)` for quick mapping from primes to buckets; include a short manual QA checklist in the file.
- Implement a small, fast shape system in `Tenney/TenneyLimitShapes.swift` with `RegularPolygon`, `DiamondShape`, `ShieldShape`, and `LimitShape` plus `limitShapePath(...)` used for node and chip silhouettes.
- Provide optional coarse pattern overlays and a tiny, reusable glyph/chip UI in `Tenney/TenneyLimitA11yViews.swift` (`TenneyLimitGlyph`, `TenneyPrimeLimitChip`, `TenneyPrimeLimitBadge`) that reuse precomputed Path patterns rather than per-node Canvas allocations.
- Update lattice node and overlay rendering to use shapes when assist mode is enabled and to clip/fill/stroke those shapes while preserving the existing visual style when disabled; selection rims keep existing behavior and add an internal marker (small dot) for non‑color selection cue (`Tenney/LatticeView.swift`).
- Replace overlay chip and tuner prime-limit chips / badges with the new shape-aware components when assist mode is active, while keeping legacy `GlassChip` / `BadgeCapsule` behavior when disabled (`Tenney/LatticeView.swift`, `Tenney/ContentView.swift`).
- Add UI toggles in ThemesCenterView under Advanced → Accessibility and wire AppStorage for live toggling (`Tenney/ThemesCenterView.swift`).
- Keep changes surgical and localized; the default behavior is preserved unless the new setting is enabled.

### Testing
- Automated tests: none executed for this change (no CI/test run performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972d97668a883278521d9c387d9ec87)