### PR TITLE
Fix theme display names in UI

### DIFF
--- a/Tenney/AboutView.swift
+++ b/Tenney/AboutView.swift
@@ -159,7 +159,7 @@ struct AboutView: View {
                         }
         
                         LabeledContent("Theme") {
-                            Text(tenneyThemeIDRaw)
+                            Text(TenneyThemeRegistry.displayName(themeIDRaw: tenneyThemeIDRaw))
                                 .lineLimit(1)
                         }
         

--- a/Tenney/Settings.swift
+++ b/Tenney/Settings.swift
@@ -3318,7 +3318,8 @@ struct StudioConsoleView: View {
         switch cat {
         case .lattice:
             let labelsPct = Int((StudioConsoleView.nearestDetent(labelDensity, in: StudioConsoleView.labelDensityDetents) * 100).rounded())
-            return "Theme: \(tenneyThemeIDRaw) · Grid: \(gridName(gridModeRaw)) · Nodes: \(nodeCode(nodeSize)) · Labels: \(labelsPct)%"
+            let themeName = TenneyThemeRegistry.displayName(themeIDRaw: tenneyThemeIDRaw)
+            return "Theme: \(themeName) · Grid: \(gridName(gridModeRaw)) · Nodes: \(nodeCode(nodeSize)) · Labels: \(labelsPct)%"
 
         case .theme:
             let style = ThemeStyleChoice(rawValue: themeStyleRaw) ?? .system
@@ -3329,7 +3330,8 @@ struct StudioConsoleView: View {
                 case .dark:   return "Dark"
                 }
             }()
-            return "Theme: \(tenneyThemeIDRaw) · Appearance: \(styleText)"
+            let themeName = TenneyThemeRegistry.displayName(themeIDRaw: tenneyThemeIDRaw)
+            return "Theme: \(themeName) · Appearance: \(styleText)"
 
         case .oscilloscope:
             let w = String(format: "%.1f", lissaRibbonWidth)

--- a/Tenney/TenneyThemeRegistry.swift
+++ b/Tenney/TenneyThemeRegistry.swift
@@ -20,6 +20,19 @@ enum TenneyThemeRegistry {
         LatticeThemeID.allCases.map { $0.rawValue }
     }
 
+    static func displayName(themeIDRaw: String) -> String {
+        if themeIDRaw.hasPrefix("custom:") {
+            let all = TenneyThemePersistence.loadAll()
+            let uuidString = themeIDRaw.replacingOccurrences(of: "custom:", with: "")
+            let id = UUID(uuidString: uuidString)
+            let theme = all.first(where: { $0.id == id })
+            return theme?.name ?? "Custom Theme"
+        }
+
+        let id = LatticeThemeID(rawValue: themeIDRaw)
+        return id?.displayName ?? themeIDRaw
+    }
+
     static func resolvedCurrent(
         themeIDRaw: String,
         scheme: ColorScheme,


### PR DESCRIPTION
### Motivation

- User-facing subtitles and the About view were showing internal theme identifiers (e.g. `classicBO`, `sodium`) instead of public display names (e.g. “Chromatic”, “Tricolor”).
- Provide a single canonical resolver to map stored theme IDs to public display names while keeping persisted IDs and routing unchanged.

### Description

- Added `TenneyThemeRegistry.displayName(themeIDRaw:)` which returns a public name for built-in IDs using `LatticeThemeID.displayName` and resolves `custom:` IDs via `TenneyThemePersistence.loadAll()` returning the saved custom theme name or `"Custom Theme"` as a fallback.
- Replaced direct raw-ID display uses in `Settings.swift` summaries and `AboutView.swift` with `TenneyThemeRegistry.displayName(themeIDRaw:)` so UI subtitles show public names instead of raw IDs.
- Kept persisted IDs and theme resolution logic unchanged and relied on existing `LatticeThemeID.displayName` for builtin mappings.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972e3d594608327bf67d9db0253f803)