### PR TITLE
Add degree-aware HEJI spelling for landmark ratios

### DIFF
--- a/Tenney/HejiNotation.swift
+++ b/Tenney/HejiNotation.swift
@@ -123,6 +123,16 @@ enum HejiNotation {
     private static let baseFifth = [0, 1, 2, 3, 4, 5, -1]
 
     private static let hejiSearchRange = -16...16
+    private static let degreeInferenceToleranceCents = 25.0
+    private static let degreeLandmarks: [(degree: Int, cents: Double)] = [
+        (1, 0.0),
+        (2, 203.910),
+        (3, 386.314),
+        (4, 498.045),
+        (5, 701.955),
+        (6, 884.359),
+        (7, 1088.269)
+    ]
 
     static func spelling(forRatio ratioRef: RatioRef, context: HejiContext) -> HejiSpelling {
         let ratio = Ratio(ratioRef.p, ratioRef.q)
@@ -132,7 +142,9 @@ enum HejiNotation {
     static func spelling(forRatio ratio: Ratio, octave: Int = 0, context: HejiContext) -> HejiSpelling {
         let value = ratio.value * pow(2.0, Double(octave))
         let folded = foldToUnit(value)
-        let best = bestThreeLimitCandidate(for: folded, preference: context.preferred)
+        let inferredDegree = inferDiatonicDegree(for: folded)
+        let forcedLetter = inferredDegree.flatMap { expectedLetter(root: rootLetter(context: context), degree: $0) }
+        let best = bestThreeLimitCandidate(for: folded, preference: context.preferred, forcedLetter: forcedLetter)
         let base = letter(for: best.e3)
         let accidental = HejiAccidental(
             diatonicAccidental: base.accidentalCount,
@@ -235,15 +247,19 @@ enum HejiNotation {
 
     // MARK: - 3-limit base
 
-    private static func bestThreeLimitCandidate(for ratio: Double, preference: AccidentalPreference) -> Candidate {
+    private static func bestThreeLimitCandidate(for ratio: Double, preference: AccidentalPreference, forcedLetter: String?) -> Candidate {
         var best: Candidate?
+        var bestFallback: Candidate?
         for e3 in hejiSearchRange {
             let base = pow(3.0, Double(e3))
             let e2 = -Int(floor(log2(base)))
             let candidate = base * pow(2.0, Double(e2))
             let cents = abs(1200.0 * log2(ratio / candidate))
-            let acc = letter(for: e3).accidentalCount
+            let letterInfo = letter(for: e3)
+            let acc = letterInfo.accidentalCount
             let candidateScore = Candidate(e3: e3, e2: e2, cents: cents, accidentalCount: acc)
+            if bestFallback == nil { bestFallback = candidateScore }
+            if let forcedLetter, letterInfo.letter != forcedLetter { continue }
             if best == nil {
                 best = candidateScore
                 continue
@@ -268,7 +284,9 @@ enum HejiNotation {
                 }
             }
         }
-        return best ?? Candidate(e3: 0, e2: 0, cents: 0, accidentalCount: 0)
+        if let best { return best }
+        if let bestFallback { return bestFallback }
+        return Candidate(e3: 0, e2: 0, cents: 0, accidentalCount: 0)
     }
 
     private static func letter(for e3: Int) -> (letter: String, accidentalCount: Int) {
@@ -276,6 +294,59 @@ enum HejiNotation {
         let base = baseFifth[idx]
         let accidental = (e3 - base) / 7
         return (fifthLetters[idx], accidental)
+    }
+
+    private static func inferDiatonicDegree(for ratio: Double) -> Int? {
+        let cents = 1200.0 * log2(ratio)
+        var best: (degree: Int, diff: Double)?
+        for landmark in degreeLandmarks {
+            let diff = abs(cents - landmark.cents)
+            if diff <= degreeInferenceToleranceCents {
+                if best == nil || diff < (best?.diff ?? .infinity) {
+                    best = (landmark.degree, diff)
+                }
+            }
+        }
+        return best?.degree
+    }
+
+    private static func expectedLetter(root: String?, degree: Int) -> String? {
+        guard let root, let rootIndex = diatonicOrder.firstIndex(of: root.uppercased()) else { return nil }
+        let offset = max(0, min(6, degree - 1))
+        let idx = (rootIndex + offset) % diatonicOrder.count
+        return diatonicOrder[idx]
+    }
+
+    private static let diatonicOrder = ["C", "D", "E", "F", "G", "A", "B"]
+
+    private static func rootLetter(context: HejiContext) -> String? {
+        guard context.rootHz.isFinite, context.rootHz > 0, context.referenceA4Hz.isFinite, context.referenceA4Hz > 0 else {
+            return nil
+        }
+        let midiFloat = 69.0 + 12.0 * log2(context.rootHz / context.referenceA4Hz)
+        let midi = Int(midiFloat.rounded())
+        let idx = ((midi % 12) + 12) % 12
+        let spelling = spelledNote(forSemitone: idx, preference: context.preferred)
+        return spelling.letter
+    }
+
+    private static func spelledNote(forSemitone idx: Int, preference: AccidentalPreference) -> (letter: String, accidentalCount: Int) {
+        let sharps: [(String, Int)] = [
+            ("C", 0), ("C", 1), ("D", 0), ("D", 1),
+            ("E", 0), ("F", 0), ("F", 1), ("G", 0),
+            ("G", 1), ("A", 0), ("A", 1), ("B", 0)
+        ]
+        let flats: [(String, Int)] = [
+            ("C", 0), ("D", -1), ("D", 0), ("E", -1),
+            ("E", 0), ("F", 0), ("G", -1), ("G", 0),
+            ("A", -1), ("A", 0), ("B", -1), ("B", 0)
+        ]
+        switch preference {
+        case .preferFlats:
+            return flats[idx]
+        case .preferSharps, .auto:
+            return sharps[idx]
+        }
     }
 
     // MARK: - Microtonal components

--- a/TenneyTests/HejiDegreeAwareSpellingTests.swift
+++ b/TenneyTests/HejiDegreeAwareSpellingTests.swift
@@ -1,0 +1,54 @@
+//
+//  HejiDegreeAwareSpellingTests.swift
+//  TenneyTests
+//
+
+import Testing
+@testable import Tenney
+
+struct HejiDegreeAwareSpellingTests {
+
+    @Test func majorSeventhDegreeUsesDiatonicLetterWithSharps() async throws {
+        let context = HejiContext(
+            referenceA4Hz: 440,
+            rootHz: 415,
+            rootRatio: nil,
+            preferred: .preferSharps,
+            maxPrime: 13,
+            allowApproximation: false,
+            scaleDegreeHint: nil
+        )
+        let spelling = HejiNotation.spelling(forRatio: RatioRef(p: 15, q: 8, octave: 0, monzo: [:]), context: context)
+        #expect(spelling.baseLetter == "F")
+        #expect(spelling.accidental.diatonicAccidental == 2)
+    }
+
+    @Test func majorSeventhDegreeUsesDiatonicLetterWithFlats() async throws {
+        let context = HejiContext(
+            referenceA4Hz: 440,
+            rootHz: 415,
+            rootRatio: nil,
+            preferred: .preferFlats,
+            maxPrime: 13,
+            allowApproximation: false,
+            scaleDegreeHint: nil
+        )
+        let spelling = HejiNotation.spelling(forRatio: RatioRef(p: 15, q: 8, octave: 0, monzo: [:]), context: context)
+        #expect(spelling.baseLetter == "G")
+        #expect(spelling.accidental.diatonicAccidental == 0)
+    }
+
+    @Test func nonLandmarkRatioFallsBackToDefaultSpelling() async throws {
+        let context = HejiContext(
+            referenceA4Hz: 440,
+            rootHz: 415,
+            rootRatio: nil,
+            preferred: .preferSharps,
+            maxPrime: 13,
+            allowApproximation: false,
+            scaleDegreeHint: nil
+        )
+        let spelling = HejiNotation.spelling(forRatio: RatioRef(p: 11, q: 8, octave: 0, monzo: [:]), context: context)
+        #expect(!spelling.baseLetter.isEmpty)
+    }
+}


### PR DESCRIPTION
### Motivation

- HEJI labels were being chosen enharmonically by accidental preference alone, which breaks diatonic scale function (e.g. a `G♯` root + `15/8` should be spelled as `F𝄪`, not `G`).

### Description

- Add degree inference constants and tolerance for common 5‑limit landmarks in `HejiNotation.swift` and infer an integer diatonic degree when a ratio is near a landmark using `inferDiatonicDegree`.
- Compute an expected diatonic letter from the spelled root with `expectedLetter` / `rootLetter` and thread that as `forcedLetter` into the 3‑limit candidate search so candidates that violate the inferred diatonic letter are excluded (with a fallback to the original search if no matching candidate exists). 
- Preserve existing scoring (minimize accidentals, honor `preferred` as a secondary tie‑breaker) and keep microtonal component handling unchanged.
- Add deterministic unit tests in `TenneyTests/HejiDegreeAwareSpellingTests.swift` that assert the `G♯` (415 Hz root) + `15/8` case yields an `F` with double‑sharp accidentals, that the `A♭` variant yields `G`, and that a non‑landmark ratio (`11/8`) falls back without crashing.

### Testing

- Added unit tests `TenneyTests/HejiDegreeAwareSpellingTests.swift` but could not run them here because `xcodebuild` is not available in this environment when attempting `xcodebuild -scheme Tenney -destination 'platform=iOS Simulator,name=iPhone 15' test` which failed. 
- No automated tests were executed in this environment, so the change is covered by new tests but they remain unverified locally in CI or a macOS environment with Xcode.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69731e5232748327a7b6417b0b763eba)