### PR TITLE
Fix HEJI degree-aware fallback scoring

### DIFF
--- a/TenneyTests/HejiDegreeAwareSpellingTests.swift
+++ b/TenneyTests/HejiDegreeAwareSpellingTests.swift
@@ -1,0 +1,54 @@
+//
+//  HejiDegreeAwareSpellingTests.swift
+//  TenneyTests
+//
+
+import Testing
+@testable import Tenney
+
+struct HejiDegreeAwareSpellingTests {
+
+    @Test func majorSeventhDegreeUsesDiatonicLetterWithSharps() async throws {
+        let context = HejiContext(
+            referenceA4Hz: 440,
+            rootHz: 415,
+            rootRatio: nil,
+            preferred: .preferSharps,
+            maxPrime: 13,
+            allowApproximation: false,
+            scaleDegreeHint: nil
+        )
+        let spelling = HejiNotation.spelling(forRatio: RatioRef(p: 15, q: 8, octave: 0, monzo: [:]), context: context)
+        #expect(spelling.baseLetter == "F")
+        #expect(spelling.accidental.diatonicAccidental == 2)
+    }
+
+    @Test func majorSeventhDegreeUsesDiatonicLetterWithFlats() async throws {
+        let context = HejiContext(
+            referenceA4Hz: 440,
+            rootHz: 415,
+            rootRatio: nil,
+            preferred: .preferFlats,
+            maxPrime: 13,
+            allowApproximation: false,
+            scaleDegreeHint: nil
+        )
+        let spelling = HejiNotation.spelling(forRatio: RatioRef(p: 15, q: 8, octave: 0, monzo: [:]), context: context)
+        #expect(spelling.baseLetter == "G")
+        #expect(spelling.accidental.diatonicAccidental == 0)
+    }
+
+    @Test func nonLandmarkRatioFallsBackToDefaultSpelling() async throws {
+        let context = HejiContext(
+            referenceA4Hz: 440,
+            rootHz: 415,
+            rootRatio: nil,
+            preferred: .preferSharps,
+            maxPrime: 13,
+            allowApproximation: false,
+            scaleDegreeHint: nil
+        )
+        let spelling = HejiNotation.spelling(forRatio: RatioRef(p: 11, q: 8, octave: 0, monzo: [:]), context: context)
+        #expect(!spelling.baseLetter.isEmpty)
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure the degree-aware HEJI spelling path preserves the original candidate scoring when a forced diatonic letter cannot be applied.
- Reduce duplicated scoring logic so forced-letter and fallback candidate selection are consistent and deterministic.

### Description

- Add a `forcedLetter` parameter to `bestThreeLimitCandidate` and compute a `bestFallback` candidate when forced-letter matching excludes options. 
- Extract shared scoring logic into a helper `chooseBestCandidate(current:candidate:preference:)` and use it for both forced and fallback selection so tie-breaking and complexity rules are identical. 
- Keep the existing degree-inference constants and diatonic-letter lookup (`degreeLandmarks`, `degreeInferenceToleranceCents`, `expectedLetter`, `rootLetter`) and thread `forcedLetter` from `spelling(forRatio:context:)` into the 3-limit search. 
- Add deterministic unit tests in `TenneyTests/HejiDegreeAwareSpellingTests.swift` that assert the `15/8` cases for sharp/flat preferences and a non-landmark fallback case. 

### Testing

- Added unit tests in `TenneyTests/HejiDegreeAwareSpellingTests.swift` but did not run them locally because `xcodebuild` is unavailable in this environment. 
- No automated tests were executed in this environment, so the new tests remain unverified here and should be run in CI or an Xcode-enabled macOS environment with `xcodebuild` or the test runner.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69731e5232748327a7b6417b0b763eba)