### PR TITLE
Tonic naming independent from Concert A4; HEJI tonic transposition and UI

### DIFF
--- a/Tenney/AppModel.swift
+++ b/Tenney/AppModel.swift
@@ -56,7 +56,12 @@ final class AppModel: ObservableObject {
     @Published var builderPresented: Bool = false
     private var _recenterObserver: NSObjectProtocol?
     init() {
-    
+        if UserDefaults.standard.object(forKey: SettingsKeys.noteNameA4Hz) == nil {
+            let legacy = UserDefaults.standard.double(forKey: SettingsKeys.staffA4Hz)
+            if legacy > 0 {
+                UserDefaults.standard.set(legacy, forKey: SettingsKeys.noteNameA4Hz)
+            }
+        }
         _recenterObserver = NotificationCenter.default.addObserver(
             forName: UIApplication.willResignActiveNotification,
             object: nil,

--- a/Tenney/HejiGalleryView.swift
+++ b/Tenney/HejiGalleryView.swift
@@ -18,18 +18,31 @@ struct HejiGalleryView: View {
     ]
 
     @AppStorage(SettingsKeys.accidentalPreference) private var accidentalPreferenceRaw: String = AccidentalPreference.auto.rawValue
-    @AppStorage(SettingsKeys.staffA4Hz) private var staffA4Hz: Double = 440
+    @AppStorage(SettingsKeys.staffA4Hz) private var concertA4Hz: Double = 440
+    @AppStorage(SettingsKeys.noteNameA4Hz) private var noteNameA4Hz: Double = 440
+    @AppStorage(SettingsKeys.tonicNameMode) private var tonicNameModeRaw: String = TonicNameMode.auto.rawValue
+    @AppStorage(SettingsKeys.tonicE3) private var tonicE3: Int = 0
 
     var body: some View {
         let pref = AccidentalPreference(rawValue: accidentalPreferenceRaw) ?? .auto
+        let mode = TonicNameMode(rawValue: tonicNameModeRaw) ?? .auto
+        let resolvedTonicE3 = TonicSpelling.resolvedTonicE3(
+            mode: mode,
+            manualE3: tonicE3,
+            rootHz: 440,
+            noteNameA4Hz: noteNameA4Hz,
+            preference: pref
+        )
         let context = HejiContext(
-            referenceA4Hz: staffA4Hz,
+            concertA4Hz: concertA4Hz,
+            noteNameA4Hz: noteNameA4Hz,
             rootHz: 440,
             rootRatio: RatioRef(p: 1, q: 1, octave: 0, monzo: [:]),
             preferred: pref,
             maxPrime: 13,
             allowApproximation: false,
-            scaleDegreeHint: nil
+            scaleDegreeHint: nil,
+            tonicE3: resolvedTonicE3
         )
 
         ScrollView {
@@ -58,4 +71,3 @@ struct HejiGalleryView: View {
     }
 }
 #endif
-

--- a/Tenney/HejiPitchLabel.swift
+++ b/Tenney/HejiPitchLabel.swift
@@ -35,9 +35,9 @@ struct HejiPitchLabel: View {
     private var ratioSpelling: HejiRatioSpelling? {
         guard case .ratio(let ratio) = pitch else { return nil }
         let pref = context.preferred
-        let anchor = resolveRootAnchor(rootHz: context.rootHz, a4Hz: context.referenceA4Hz, preference: pref)
+        let anchor = resolveRootAnchor(rootHz: context.rootHz, a4Hz: context.noteNameA4Hz, preference: pref)
         let ratioContext = PitchContext(
-            a4Hz: context.referenceA4Hz,
+            a4Hz: context.noteNameA4Hz,
             rootHz: context.rootHz,
             rootAnchor: anchor,
             accidentalPreference: pref,

--- a/Tenney/NotationFormatter.swift
+++ b/Tenney/NotationFormatter.swift
@@ -99,8 +99,7 @@ public enum NotationFormatter {
     /// HEJI-ish text label for ratio tiles / info cards.
     /// Keeps this robust/legible: `C♯4 +14¢` (or no cents if near ET).
     public static func hejiLabel(p: Int, q: Int, freqHz: Double, rootHz: Double) -> String {
-        let a4Hz = UserDefaults.standard.double(forKey: SettingsKeys.staffA4Hz)
-        let reference = a4Hz > 0 ? a4Hz : 440.0
+        let reference = TonicSpelling.resolvedNoteNameA4Hz()
         let anchor = resolveRootAnchor(rootHz: rootHz, a4Hz: reference, preference: .auto)
         let context = PitchContext(
             a4Hz: reference,

--- a/Tenney/OnboardingWizardView.swift
+++ b/Tenney/OnboardingWizardView.swift
@@ -31,7 +31,7 @@ struct OnboardingWizardView: View {
     @EnvironmentObject private var app: AppModel
     @AppStorage(SettingsKeys.setupWizardDone) private var setupWizardDone: Bool = false
     @AppStorage(SettingsKeys.defaultView)    private var defaultView: String = "tuner" // "lattice" | "tuner"
-    @AppStorage(SettingsKeys.staffA4Hz)      private var a4Staff: Double = 440
+    @AppStorage(SettingsKeys.noteNameA4Hz)      private var noteNameA4Hz: Double = 440
 
     // Steps: 0=Root, 1=A4, 2=Theme/Style, 3=Default Screen
     @State private var step: Int = 0
@@ -77,8 +77,8 @@ struct OnboardingWizardView: View {
                     rootPreset = m
                 } else { rootPreset = nil }
                 
-                a4CustomHz = a4Staff
-                if let m = a4Presets.first(where: { abs($0 - a4Staff) < 0.01 }) {
+                a4CustomHz = noteNameA4Hz
+                if let m = a4Presets.first(where: { abs($0 - noteNameA4Hz) < 0.01 }) {
                     a4Preset = m
                 } else { a4Preset = nil }
             }
@@ -211,14 +211,14 @@ struct OnboardingWizardView: View {
     }
     private var currentA4Hz: Double { a4Preset ?? max(200, min(1000, a4CustomHz)) }
     private func selectA4(_ hz: Double) {
-        withAnimation(.snappy) { a4Preset = hz; a4Staff = hz }
-        postSetting(SettingsKeys.staffA4Hz, hz)
+        withAnimation(.snappy) { a4Preset = hz; noteNameA4Hz = hz }
+        postSetting(SettingsKeys.noteNameA4Hz, hz)
         if previewA4On { setTone(hz) }
     }
     private func commitA4Custom() {
         let hz = currentA4Hz
-        a4Staff = hz
-        postSetting(SettingsKeys.staffA4Hz, hz)
+        noteNameA4Hz = hz
+        postSetting(SettingsKeys.noteNameA4Hz, hz)
         if previewA4On { setTone(hz) }
     }
 

--- a/Tenney/Ratio+Octave.swift
+++ b/Tenney/Ratio+Octave.swift
@@ -106,7 +106,8 @@ func ratioDisplayString(_ r: RatioRef) -> String {
 
 /// If you need name/octave from an effective frequency (cents vs ET can be filled by your model later)
 func hejiDisplay(freqHz: Double) -> (name: String, oct: Int, cents: Double) {
-    let (name, oct) = NotationFormatter.staffNoteName(freqHz: freqHz)
+    let reference = TonicSpelling.resolvedNoteNameA4Hz()
+    let (name, oct) = NotationFormatter.staffNoteName(freqHz: freqHz, a4Hz: reference)
     // If you want ET cents here, compute it using your own ET helper.
     return (name, oct, 0)
 }

--- a/Tenney/Settings.swift
+++ b/Tenney/Settings.swift
@@ -407,7 +407,7 @@ struct StudioConsoleView: View {
     // Tuning
     @AppStorage(SettingsKeys.a4Choice)   private var a4Choice = A4Choice._440.rawValue
     @AppStorage(SettingsKeys.a4CustomHz) private var a4Custom: Double = 440
-    @AppStorage(SettingsKeys.staffA4Hz)  private var a4Staff: Double = 440
+    @AppStorage(SettingsKeys.noteNameA4Hz)  private var noteNameA4Hz: Double = 440
 
     // Labels
     @AppStorage(SettingsKeys.labelDefault)       private var labelDefault = "ratio" // "ratio" | "heji"
@@ -2796,7 +2796,7 @@ struct StudioConsoleView: View {
             SettingsChangeSinks(
                 tunerNeedleHoldRaw: $tunerNeedleHoldRaw,
                 defaultView: $defaultView,
-                a4Staff: $a4Staff,
+                noteNameA4Hz: $noteNameA4Hz,
                 labelDefault: $labelDefault,
                 showRatioAlong: $showRatioAlong,
                 infoCardNotationModeRaw: $infoCardNotationModeRaw,
@@ -3350,7 +3350,7 @@ struct StudioConsoleView: View {
             let dimText = dimLocked ? "Dim: Locked" : "Dim: \(Int((stageDimLevel * 100).rounded()))%"
             let accent = stageAccent.capitalized
 
-            return "A4: \(Int(a4Staff.rounded())) Hz · Needle: \(needle) · \(dimText) · Accent: \(accent)"
+            return "A4: \(Int(noteNameA4Hz.rounded())) Hz · Needle: \(needle) · \(dimText) · Accent: \(accent)"
 
 
         case .general:
@@ -3739,7 +3739,7 @@ private struct GlassNavTile<Destination: View>: View {
         
         @Binding var tunerNeedleHoldRaw: String
         @Binding var defaultView: String
-        @Binding var a4Staff: Double
+        @Binding var noteNameA4Hz: Double
         @Binding var labelDefault: String
         @Binding var showRatioAlong: Bool
         @Binding var infoCardNotationModeRaw: String
@@ -3805,7 +3805,7 @@ private struct GlassNavTile<Destination: View>: View {
                     LearnEventBus.shared.send(.tunerConfidenceGateChanged(gateValue))
                 }
                 .onChange(of: defaultView)   { postSetting(SettingsKeys.defaultView, $0) }
-                .onChange(of: a4Staff)       { postSetting(SettingsKeys.staffA4Hz, $0) }
+                .onChange(of: noteNameA4Hz)  { postSetting(SettingsKeys.noteNameA4Hz, $0) }
                 .onChange(of: labelDefault)  { postSetting(SettingsKeys.labelDefault, $0) }
                 .onChange(of: showRatioAlong){ postSetting(SettingsKeys.showRatioAlongHeji, $0) }
                 .onChange(of: infoCardNotationModeRaw) { postSetting(SettingsKeys.infoCardNotationMode, $0) }
@@ -4646,7 +4646,7 @@ private struct GlassNavTile<Destination: View>: View {
         postSetting(SettingsKeys.overlay11, overlay11)
         postSetting(SettingsKeys.foldAudible, foldAudible)
         postSetting(SettingsKeys.safeAmp, safeAmp)
-        postSetting(SettingsKeys.staffA4Hz, a4Staff)
+        postSetting(SettingsKeys.noteNameA4Hz, noteNameA4Hz)
         postSetting(SettingsKeys.stageDimLevel, stageDimLevel)
         postSetting(SettingsKeys.stageAccent, stageAccent)
         postSetting(SettingsKeys.stageHideStatus, stageHideStatus)

--- a/Tenney/SettingsA4PickerView.swift
+++ b/Tenney/SettingsA4PickerView.swift
@@ -12,14 +12,14 @@
 //
 //  Re-styled A4 reference picker using the same card language as SettingsThemePickerView.
 //  - Presets: 425 / 440 / 442 / 444 + Custom
-//  - Writes to @AppStorage(SettingsKeys.staffA4Hz)
+//  - Writes to @AppStorage(SettingsKeys.noteNameA4Hz)
 //  - Calls onSelectionChanged(hz) when the value changes (used by the wizard for live preview)
 //
 
 import SwiftUI
 
 struct SettingsA4PickerView: View {
-    @AppStorage(SettingsKeys.staffA4Hz) private var staffA4Hz: Double = 440
+    @AppStorage(SettingsKeys.noteNameA4Hz) private var noteNameA4Hz: Double = 440
 
     var onSelectionChanged: ((Double) -> Void)? = nil
 
@@ -100,7 +100,7 @@ struct SettingsA4PickerView: View {
 
     // MARK: - Logic
     private func syncFromStored() {
-        let current = staffA4Hz
+        let current = noteNameA4Hz
         if let match = [425.0, 440.0, 442.0, 444.0].first(where: { abs($0 - current) < 0.01 }) {
             switch match {
             case 425: selected = ._425
@@ -119,8 +119,8 @@ struct SettingsA4PickerView: View {
         if let hz = p.hz {
             commit(hz)
         } else {
-            // keep customHz; selecting custom doesn’t change staffA4Hz until edited
-            customHz = staffA4Hz
+            // keep customHz; selecting custom doesn’t change noteNameA4Hz until edited
+            customHz = noteNameA4Hz
         }
     }
 
@@ -130,8 +130,8 @@ struct SettingsA4PickerView: View {
     }
 
     private func commit(_ hz: Double) {
-        staffA4Hz = hz
-        postSetting(SettingsKeys.staffA4Hz, hz)
+        noteNameA4Hz = hz
+        postSetting(SettingsKeys.noteNameA4Hz, hz)
         onSelectionChanged?(hz)
     }
 }

--- a/Tenney/SettingsKeys.swift
+++ b/Tenney/SettingsKeys.swift
@@ -53,7 +53,8 @@ enum SettingsKeys {
     // Tuning
     static let a4Choice      = "tenney.tuner.a4Choice"     // "440" | "442" | "custom"
     static let a4CustomHz    = "tenney.tuner.a4CustomHz"   // Double
-    static let staffA4Hz     = "tenney.tuner.staffA4Hz"    // Double (cached, used by NotationFormatter)
+    static let staffA4Hz     = "tenney.tuner.staffA4Hz"    // Double (concert pitch A4)
+    static let noteNameA4Hz  = "tenney.noteName.a4Hz"      // Double (absolute note-name reference)
     // Tuner UI style (Gauge vs Chrono Dial vs Scope)
     static let tunerViewStyle = "Tenney.Tuner.ViewStyle"
 
@@ -91,6 +92,8 @@ enum SettingsKeys {
     static let rootAnchorFifthsFromC = "tenney.label.rootAnchor.fifthsFromC" // Int
     static let rootAnchorDiatonicNumber = "tenney.label.rootAnchor.diatonicNumber" // Int
     static let rootAnchorIsFrozen = "tenney.label.rootAnchor.isFrozen" // Bool
+    static let tonicNameMode = "tenney.label.tonicName.mode" // "auto" | "manual"
+    static let tonicE3 = "tenney.label.tonicE3" // Int (fifths exponent for tonic spelling)
 
     // Lattice UI
     static let nodeSize      = "tenney.ui.nodeSize"        // "s" | "m" | "mplus" | "l"

--- a/Tenney/Utils/TonicSpelling.swift
+++ b/Tenney/Utils/TonicSpelling.swift
@@ -1,0 +1,112 @@
+//
+//  TonicSpelling.swift
+//  Tenney
+//
+//  Root-name utilities for HEJI spelling.
+//
+
+import Foundation
+
+enum TonicNameMode: String, CaseIterable, Identifiable {
+    case auto
+    case manual
+
+    var id: String { rawValue }
+}
+
+struct TonicSpelling: Hashable {
+    var e3: Int
+
+    var letter: String { letterInfo.letter }
+    var accidentalCount: Int { letterInfo.accidentalCount }
+
+    var displayText: String {
+        letter + accidentalText(for: accidentalCount)
+    }
+
+    private var letterInfo: (letter: String, accidentalCount: Int) {
+        let idx = ((e3 % 7) + 7) % 7
+        let base = Self.baseFifth[idx]
+        let accidental = (e3 - base) / 7
+        return (Self.fifthLetters[idx], accidental)
+    }
+
+    static func from(rootHz: Double, noteNameA4Hz: Double, preference: AccidentalPreference) -> TonicSpelling? {
+        guard rootHz.isFinite, rootHz > 0, noteNameA4Hz.isFinite, noteNameA4Hz > 0 else { return nil }
+        let midiFloat = 69.0 + 12.0 * log2(rootHz / noteNameA4Hz)
+        let midi = Int(midiFloat.rounded())
+        let idx = ((midi % 12) + 12) % 12
+        let spelling = spelledNote(forSemitone: idx, preference: preference)
+        return from(letter: spelling.letter, accidental: spelling.accidentalCount)
+    }
+
+    static func from(letter: String, accidental: Int) -> TonicSpelling {
+        let base = naturalFifths(letter)
+        return TonicSpelling(e3: base + (7 * accidental))
+    }
+
+    static func resolvedTonicE3(
+        mode: TonicNameMode,
+        manualE3: Int,
+        rootHz: Double,
+        noteNameA4Hz: Double,
+        preference: AccidentalPreference
+    ) -> Int? {
+        switch mode {
+        case .manual:
+            return manualE3
+        case .auto:
+            return TonicSpelling.from(rootHz: rootHz, noteNameA4Hz: noteNameA4Hz, preference: preference)?.e3
+        }
+    }
+
+    static func resolvedNoteNameA4Hz(defaults: UserDefaults = .standard) -> Double {
+        if defaults.object(forKey: SettingsKeys.noteNameA4Hz) != nil {
+            let value = defaults.double(forKey: SettingsKeys.noteNameA4Hz)
+            return value > 0 ? value : 440.0
+        }
+        let legacy = defaults.double(forKey: SettingsKeys.staffA4Hz)
+        return legacy > 0 ? legacy : 440.0
+    }
+
+    private static let fifthLetters = ["C", "G", "D", "A", "E", "B", "F"]
+    private static let baseFifth = [0, 1, 2, 3, 4, 5, -1]
+
+    private static func naturalFifths(_ letter: String) -> Int {
+        switch letter.uppercased() {
+        case "C": return 0
+        case "G": return 1
+        case "D": return 2
+        case "A": return 3
+        case "E": return 4
+        case "B": return 5
+        case "F": return -1
+        default: return 0
+        }
+    }
+
+    private static func spelledNote(forSemitone idx: Int, preference: AccidentalPreference) -> (letter: String, accidentalCount: Int) {
+        let sharps: [(String, Int)] = [
+            ("C", 0), ("C", 1), ("D", 0), ("D", 1),
+            ("E", 0), ("F", 0), ("F", 1), ("G", 0),
+            ("G", 1), ("A", 0), ("A", 1), ("B", 0)
+        ]
+        let flats: [(String, Int)] = [
+            ("C", 0), ("D", -1), ("D", 0), ("E", -1),
+            ("E", 0), ("F", 0), ("G", -1), ("G", 0),
+            ("A", -1), ("A", 0), ("B", -1), ("B", 0)
+        ]
+        switch preference {
+        case .preferFlats:
+            return flats[idx]
+        case .preferSharps, .auto:
+            return sharps[idx]
+        }
+    }
+
+    private func accidentalText(for count: Int) -> String {
+        if count > 0 { return String(repeating: "♯", count: count) }
+        if count < 0 { return String(repeating: "♭", count: abs(count)) }
+        return ""
+    }
+}

--- a/TenneyTests/HejiDegreeAwareSpellingTests.swift
+++ b/TenneyTests/HejiDegreeAwareSpellingTests.swift
@@ -8,47 +8,57 @@ import Testing
 
 struct HejiDegreeAwareSpellingTests {
 
-    @Test func majorSeventhDegreeUsesDiatonicLetterWithSharps() async throws {
+    @Test func manualTonicTransposesIntervalLetter() async throws {
+        let tonic = TonicSpelling.from(letter: "G", accidental: 1)
         let context = HejiContext(
-            referenceA4Hz: 440,
+            concertA4Hz: 440,
+            noteNameA4Hz: 440,
             rootHz: 415,
             rootRatio: nil,
             preferred: .preferSharps,
             maxPrime: 13,
             allowApproximation: false,
-            scaleDegreeHint: nil
+            scaleDegreeHint: nil,
+            tonicE3: tonic.e3
         )
         let spelling = HejiNotation.spelling(forRatio: RatioRef(p: 15, q: 8, octave: 0, monzo: [:]), context: context)
         #expect(spelling.baseLetter == "F")
         #expect(spelling.accidental.diatonicAccidental == 2)
     }
 
-    @Test func majorSeventhDegreeUsesDiatonicLetterWithFlats() async throws {
-        let context = HejiContext(
-            referenceA4Hz: 440,
-            rootHz: 415,
-            rootRatio: nil,
-            preferred: .preferFlats,
-            maxPrime: 13,
-            allowApproximation: false,
-            scaleDegreeHint: nil
-        )
-        let spelling = HejiNotation.spelling(forRatio: RatioRef(p: 15, q: 8, octave: 0, monzo: [:]), context: context)
-        #expect(spelling.baseLetter == "G")
-        #expect(spelling.accidental.diatonicAccidental == 0)
-    }
-
-    @Test func nonLandmarkRatioFallsBackToDefaultSpelling() async throws {
-        let context = HejiContext(
-            referenceA4Hz: 440,
+    @Test func concertPitchDoesNotAffectLetterChoice() async throws {
+        let tonic = TonicSpelling.from(letter: "G", accidental: 1)
+        let context440 = HejiContext(
+            concertA4Hz: 440,
+            noteNameA4Hz: 440,
             rootHz: 415,
             rootRatio: nil,
             preferred: .preferSharps,
             maxPrime: 13,
             allowApproximation: false,
-            scaleDegreeHint: nil
+            scaleDegreeHint: nil,
+            tonicE3: tonic.e3
         )
-        let spelling = HejiNotation.spelling(forRatio: RatioRef(p: 11, q: 8, octave: 0, monzo: [:]), context: context)
-        #expect(!spelling.baseLetter.isEmpty)
+        let context415 = HejiContext(
+            concertA4Hz: 415,
+            noteNameA4Hz: 440,
+            rootHz: 415,
+            rootRatio: nil,
+            preferred: .preferSharps,
+            maxPrime: 13,
+            allowApproximation: false,
+            scaleDegreeHint: nil,
+            tonicE3: tonic.e3
+        )
+        let spelling440 = HejiNotation.spelling(forRatio: RatioRef(p: 15, q: 8, octave: 0, monzo: [:]), context: context440)
+        let spelling415 = HejiNotation.spelling(forRatio: RatioRef(p: 15, q: 8, octave: 0, monzo: [:]), context: context415)
+        #expect(spelling440.baseLetter == spelling415.baseLetter)
+        #expect(spelling440.accidental.diatonicAccidental == spelling415.accidental.diatonicAccidental)
+    }
+
+    @Test func autoTonicDerivationUsesNamingReference() async throws {
+        let spelling = TonicSpelling.from(rootHz: 415, noteNameA4Hz: 440, preference: .preferSharps)
+        #expect(spelling?.letter == "G")
+        #expect(spelling?.accidentalCount == 1)
     }
 }

--- a/TenneyTests/HejiNotationTests.swift
+++ b/TenneyTests/HejiNotationTests.swift
@@ -9,13 +9,15 @@ import Testing
 struct HejiNotationTests {
 
     private let context = HejiContext(
-        referenceA4Hz: 440,
+        concertA4Hz: 440,
+        noteNameA4Hz: 440,
         rootHz: 440,
         rootRatio: nil,
         preferred: .auto,
         maxPrime: 13,
         allowApproximation: false,
-        scaleDegreeHint: nil
+        scaleDegreeHint: nil,
+        tonicE3: nil
     )
 
     @Test func threeLimitLetters() async throws {
@@ -46,4 +48,3 @@ struct HejiNotationTests {
         #expect(tridecimal.accidental.microtonalComponents.contains(.tridecimal(up: false)))
     }
 }
-


### PR DESCRIPTION
### Motivation
- Make tonic spelling independent from the Concert Pitch A4 used for audio, by introducing a separate Naming Reference A4Hz (`noteNameA4Hz`) and a tonic naming mode (auto/manual). 
- Ensure HEJI note-name rendering is tonic-relative by transposing interval fifths into the tonic domain instead of forcing letters via the previous degree-landmark approach. 

### Description
- Add `TonicSpelling` utilities and settings: new `noteNameA4Hz`, `tonicNameMode`, and `tonicE3` keys and the `TonicSpelling` type with helpers to derive/display tonic spellings and resolve the naming A4Hz. (files: `Tenney/Utils/TonicSpelling.swift`, `Tenney/SettingsKeys.swift`, `Tenney/AppModel.swift`) 
- Update HEJI core to compute 3-limit candidate e3 and then apply tonic fifths transposition when `tonicE3` is present, and use the naming A4 (`noteNameA4Hz`) for staff/octave logic; removed the old degree/forced-letter heuristic. (file: `Tenney/HejiNotation.swift`) 
- Wire naming settings through UI and view contexts: add “Name as” picker (Auto/Manual) and picker sheet, persist manual tonic via `tonicE3`, and pass `concertA4Hz` vs `noteNameA4Hz` appropriately across tuner, lattice, builder, gallery, settings and onboarding. (files: `Tenney/ContentView.swift`, `Tenney/LatticeView.swift`, `Tenney/ScaleBuilderScreen.swift`, `Tenney/ScaleLibrarySheet.swift`, `Tenney/HejiGalleryView.swift`, `Tenney/HejiPitchLabel.swift`, `Tenney/SettingsA4PickerView.swift`, `Tenney/OnboardingWizardView.swift`, `Tenney/Settings.swift`, `Tenney/NotationFormatter.swift`, `Tenney/Ratio+Octave.swift`) 
- Replace legacy usages of the old A4 key for naming with the new naming reference where appropriate and preserve `concertA4Hz` for audio/test-tone behaviors. 
- Add unit tests to validate tonic transposition, independence from concert A4, and auto tonic derivation. (files: `TenneyTests/HejiDegreeAwareSpellingTests.swift`, `TenneyTests/HejiNotationTests.swift`) 

### Testing
- Added unit tests that exercise the exact bug cases: manual tonic transposition (15/8 with tonic G♯ → expects F𝄪), concert-pitch independence (same spelling with Concert A4=415 vs 440), and auto tonic derivation from rootHz + naming reference; these tests were committed in `TenneyTests/HejiDegreeAwareSpellingTests.swift` and related test updates. 
- No automated test run was executed as part of this patch; CI / local test run is recommended to validate the changed behavior end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69732e445ba48327bf848fc1786524fc)