### PR TITLE
Add Root Pitch & Tuning Configuration reference-only Learn module

### DIFF
--- a/Tenney/ContentView.swift
+++ b/Tenney/ContentView.swift
@@ -2678,7 +2678,7 @@ private struct RootStudioSheet: View {
         .onChange(of: manualAccidental) { _, _ in updateManualE3IfNeeded() }
         .sheet(isPresented: $showReference) {
             NavigationStack {
-                LearnTenneyReferenceTopicView(topic: .rootTonicConcert)
+                LearnTenneyHubView(entryPoint: .settings)
             }
         }
     }
@@ -2942,6 +2942,8 @@ private struct RootStudioSheet: View {
             let emphasisOpacity = referenceEmphasis ? 0.9 : 0.0
             return glassCard("Reference") {
                 Button {
+                    LearnTenneyStateStore.shared.pendingModuleToOpen = .rootPitchTuningConfig
+                    LearnTenneyStateStore.shared.pendingReferenceTopic = .rootTonicConcert
                     showReference = true
                 } label: {
                     HStack(spacing: 12) {

--- a/Tenney/LearnOverlay.swift
+++ b/Tenney/LearnOverlay.swift
@@ -295,6 +295,7 @@ private struct LearnCompletionView: View {
         case .lattice: return "Lattice is ready."
         case .tuner: return "Tuner is ready."
         case .builder: return "Builder is ready."
+        case .rootPitchTuningConfig: return "Reference is ready."
         }
     }
 
@@ -306,6 +307,8 @@ private struct LearnCompletionView: View {
             return ["Switch views", "Use lock", "Use stage mode"]
         case .builder:
             return ["Play pads", "Add root", "Hear blends"]
+        case .rootPitchTuningConfig:
+            return ["Review root vs tonic", "Check concert pitch", "Debug labels"]
         }
     }
 

--- a/Tenney/LearnStepFactory.swift
+++ b/Tenney/LearnStepFactory.swift
@@ -169,6 +169,8 @@ enum LearnStepFactory {
                     validate: { $0 == .builderScopeTimedSatisfied }
                 )
             ]
+        case .rootPitchTuningConfig:
+            return []
         }
     }
 }

--- a/Tenney/LearnTenneyPractice.swift
+++ b/Tenney/LearnTenneyPractice.swift
@@ -179,6 +179,9 @@ private struct PracticeContent: View {
 
             case .builder:
                 BuilderPracticeHost()
+
+            case .rootPitchTuningConfig:
+                EmptyView()
             }
         }
     }

--- a/Tenney/LearnTenneyReference.swift
+++ b/Tenney/LearnTenneyReference.swift
@@ -10,6 +10,44 @@ struct LearnControlRef: Identifiable, Hashable {
     let focus: LearnPracticeFocus?
 }
 
+struct LearnTenneyReferenceTopicsListView: View {
+    let module: LearnTenneyModule
+    @Binding var selectedTopic: LearnReferenceTopic?
+
+    var body: some View {
+        List {
+            ForEach(module.referenceTopics) { topic in
+                NavigationLink(tag: topic, selection: $selectedTopic) {
+                    LearnTenneyReferenceTopicView(topic: topic, module: module)
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: topic.systemImage)
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundStyle(.tint)
+                            .frame(width: 30, height: 30)
+                            .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(topic.title)
+                                .font(.headline)
+                            Text(topic.subtitle)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+
+                        Spacer()
+                    }
+                    .padding(.vertical, 2)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(Text(topic.title))
+                    .accessibilityValue(Text(topic.subtitle))
+                }
+            }
+        }
+    }
+}
+
 struct LearnTenneyReferenceListView: View {
     let module: LearnTenneyModule
     var onTryInPractice: (LearnPracticeFocus) -> Void
@@ -171,6 +209,8 @@ struct LearnTenneyReferenceListView: View {
                     focus: .builderOscilloscope
                 )
             ]
+        case .rootPitchTuningConfig:
+            return []
         }
     }
 }

--- a/Tenney/LearnTenneyReferenceSeries.swift
+++ b/Tenney/LearnTenneyReferenceSeries.swift
@@ -50,6 +50,7 @@ enum LearnReferenceTopic: String, CaseIterable, Identifiable, Sendable {
 
 struct LearnTenneyReferenceTopicView: View {
     let topic: LearnReferenceTopic
+    let module: LearnTenneyModule? = nil
 
     var body: some View {
         ScrollView {
@@ -70,6 +71,11 @@ struct LearnTenneyReferenceTopicView: View {
         }
         .navigationTitle(topic.title)
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            if let module {
+                TenneyPracticeSnapshot.shared.markReferenceCompleted(module, topic: topic)
+            }
+        }
     }
 }
 

--- a/Tenney/LearnTenneyTour.swift
+++ b/Tenney/LearnTenneyTour.swift
@@ -114,6 +114,7 @@ struct LearnTenneyTourView: View {
         case .lattice: latticeDone = true
         case .tuner: tunerDone = true
         case .builder: builderDone = true
+        case .rootPitchTuningConfig: break
         }
     }
 
@@ -265,6 +266,8 @@ struct LearnTenneyTourView: View {
                     tryIt: "Make two tones interact (or use pads) and watch the shape evolve."
                 )
             ]
+        case .rootPitchTuningConfig:
+            return []
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Consolidate previously standalone reference lessons into a proper Learn Module so they appear under the existing Modules group (Lattice/Tuner/Builder) and not as top-level reference items. 
- Provide module-level completion for a Reference-only module and enable a CTA deep-link from the Root picker to open the new module and jump into its primary lesson. 

### Description
- Added a new module id `rootPitchTuningConfig` to `LearnTenneyModule` with `supportsPractice = false`, `supportsReference = true`, `referenceTopics = LearnReferenceTopic.allCases`, and a friendly title/icon/subtitle. 
- Updated the hub UI (`LearnTenneyHubView`) to expose the new module in the Modules section (under Builder) and replaced the standalone Reference list with per-module reference navigation and a generic footer. 
- Made the module detail view capability-driven (`LearnTenneyModuleView`) so segmented Practice/Reference picker hides for reference-only modules and a `LearnTenneyReferenceTopicsListView` presents the reference topics for the new module. 
- Introduced per-topic reference completion in `TenneyPracticeSnapshot` via `markReferenceCompleted`/`isReferenceCompleted` and `referenceState(for:)`, and added `pendingReferenceTopic` to `LearnTenneyStateStore` to support deep-link navigation. 
- Wired the Root picker CTA (`ContentView`) to set `pendingModuleToOpen = .rootPitchTuningConfig` and `pendingReferenceTopic = .rootTonicConcert` so the sheet opens Learn → Root Pitch & Tuning Configuration → Reference → Root Hz, Tonic, Concert Pitch without pasteboard usage. 
- Kept practice codepaths intact and non-invasive by returning empty practice steps for the new module and using `EmptyView()` where practice would otherwise render. 
- Completion for the new module is computed in `TenneyPracticeSnapshot.referenceState(for:)`, which aggregates per-topic completion keys (`learn.<module>.reference.<topic>.completed`) and updates `LearnTenneyStateStore`. 

### Testing
- Automated tests: none were executed in this change; no CI or unit test runs were performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973416e03508327967351ace244b46e)