### PR TITLE
Unify tonic label + prevent truncation in UtilityBar and Tuner root chips

### DIFF
--- a/Tenney/ContentView.swift
+++ b/Tenney/ContentView.swift
@@ -2006,6 +2006,9 @@ private struct UtilityBar: View {
     private var rootValueText: some View {
         Text(String(format: "%.1f", app.rootHz))
             .font(.footnote.monospacedDigit().weight(.semibold))
+            .lineLimit(1)
+            .minimumScaleFactor(0.8)
+            .allowsTightening(true)
             .contentTransition(.numericText())
     }
 
@@ -2078,10 +2081,17 @@ private struct UtilityBar: View {
                 }
             }
 
-            // Compact: value only
-            rootValueTextMaybeHero()
+            // Compact: value + tonic
+            HStack(spacing: 3) {
+                rootValueTextMaybeHero()
+                tonicNameLabel
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
         }
         .lineLimit(1)
+        .minimumScaleFactor(0.8)
+        .allowsTightening(true)
     }
 
     private var tonicNameLabel: some View {
@@ -2092,9 +2102,10 @@ private struct UtilityBar: View {
             noteNameA4Hz: noteNameA4Hz,
             accidentalPreferenceRaw: accidentalPreferenceRaw
         ))
-        .frame(width: 34, alignment: .center)
+        .frame(minWidth: 34, alignment: .center)
         .lineLimit(1)
         .minimumScaleFactor(0.7)
+        .allowsTightening(true)
     }
 
 
@@ -2442,24 +2453,29 @@ private struct RootCardCompact: View {
                     Button {
                         showSheet = true
                     } label: {
+                        let tonicDisplayName = currentTonicDisplayName(
+                            modeRaw: tonicNameModeRaw,
+                            manualE3: tonicE3,
+                            rootHz: model.rootHz,
+                            noteNameA4Hz: noteNameA4Hz,
+                            accidentalPreferenceRaw: accidentalPreferenceRaw
+                        )
                         HStack(spacing: 6) {
                             Image(systemName: "tuningfork")
                                 .imageScale(.medium)
                             Text(String(format: "%.1f", model.rootHz))
                                 .font(.headline.monospacedDigit())
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.75)
+                                .allowsTightening(true)
                                 .matchedGeometryEffect(id: "rootValue", in: ns)  // ← hero
-                            Text(currentTonicDisplayName(
-                                modeRaw: tonicNameModeRaw,
-                                manualE3: tonicE3,
-                                rootHz: model.rootHz,
-                                noteNameA4Hz: noteNameA4Hz,
-                                accidentalPreferenceRaw: accidentalPreferenceRaw
-                            ))
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                            .frame(width: 34, alignment: .center)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.7)
+                            Text(tonicDisplayName)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                                .frame(minWidth: 34, alignment: .center)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.7)
+                                .allowsTightening(true)
                         }
                         .padding(.horizontal, 10).padding(.vertical, 6)
                         .background(.thinMaterial, in: Capsule())


### PR DESCRIPTION
### Motivation
- Stabilize and unify the root/tonic label shown in both the UtilityBar pill and the Tuner root chip so the tonic name is visible and identical on first render. 
- Avoid the regression where the UtilityBar pill shows correct label in Lattice but the Tuner view shows only a small Hz-only pill or a blank/clipped label until tab switching. 
- Keep this strictly a display/labeling change with no tuning/audio behavior changes and no new sheets.

### Description
- Kept and reused the existing pure computed helper `currentTonicDisplayName(...)` for both controls so the tonic name is derived (not stored in @State) and available on first render. (Updated `Tenney/ContentView.swift`.)
- Prevented clipping/truncation by enabling scale-down and tightening on root label views: added `lineLimit(1)`, `minimumScaleFactor(...)`, and `allowsTightening(true)` to `rootValueText`, `rootChipLabel`, and tuner root chip text.
- Ensured tonic label is always present in the compact UtilityBar variant by replacing the previous value-only compact fallback with a compact `HStack` that includes the tonic label, and changed the tonic label frame from a fixed width to `minWidth` to avoid overly-small clipping.
- Made the compact root chip in `RootCardCompact` compute a local `tonicDisplayName` and use it directly for the label so it is non-empty on initial render and benefits from the same scaling settings.

### Testing
- Automated tests: none were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697345292e548327b1f9b814cb6d33aa)