### PR TITLE
Add central mic/tuner lease manager and switch Learn to use leases

### DIFF
--- a/Tenney/LearnTenneyHubView.swift
+++ b/Tenney/LearnTenneyHubView.swift
@@ -82,7 +82,6 @@ struct LearnTenneyHubView: View {
     @State private var activeModule: LearnTenneyModule? = nil
     @Environment(\.tenneyTheme) private var theme
     @Environment(\.horizontalSizeClass) private var sizeClass
-    @EnvironmentObject private var app: AppModel
 
     var body: some View {
         List {
@@ -157,9 +156,6 @@ struct LearnTenneyHubView: View {
             guard let pending else { return }
             activeModule = pending
             store.pendingModuleToOpen = nil
-        }
-        .onDisappear {
-            app.setPipelineActive(false, reason: "learn_practice_dismiss")
         }
     }
 

--- a/Tenney/LearnTenneyPractice.swift
+++ b/Tenney/LearnTenneyPractice.swift
@@ -254,14 +254,16 @@ private struct LatticePracticeHost: View {
 private struct TunerPracticeHost: View {
     @State private var stageActive = false
     @StateObject private var tunerStore = TunerStore()
+    @State private var tunerLease: MicTunerLeaseManager.LeaseToken?
     @EnvironmentObject private var app: AppModel
     var body: some View {
         TunerCard(store: tunerStore, stageActive: $stageActive)
             .onAppear {
-                app.setPipelineActive(true, reason: "learn_practice_tuner")
+                tunerLease = app.acquireTunerLease(reason: "learn_practice_tuner")
             }
             .onDisappear {
-                app.setPipelineActive(false, reason: "learn_practice_tuner")
+                tunerLease?.release()
+                tunerLease = nil
             }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent Learn Tenney from forcing the app tuner engine off when leaving Learn by making Learn a client (lease-holder) instead of an owner. 
- Provide a single source of truth for whether the mic/tuner pipeline should be running by reconciling user intent with active Learn usage.

### Description
- Add `MicTunerLeaseManager` to `Tenney/AppModel.swift` with reference-counted `LeaseToken` that automatically releases on `deinit`, and an `acquire(reason:)` API for clients. 
- Reconcile effective engine intent in `AppModel` via `userWantsTunerOn || tunerLeaseManager.activeLeaseCount > 0` in a new `updatePipelineWanted(reason:)` helper so the engine runs if the user wants it or any lease is active and only stops when no lease is active and the user does not want it. 
- Expose `acquireTunerLease(reason:)` on `AppModel` and replace Learn practice direct calls to `setPipelineActive` with acquiring a lease in `Tenney/LearnTenneyPractice.swift` (lease acquired on appear, released on disappear). 
- Remove the Learn hub’s `.onDisappear` call that previously forced `setPipelineActive(false)` so exiting Learn no longer forces the tuner off. 
- Keep UI behavior otherwise unchanged; added minimal inline comments near the lease implementation explaining the invariant and safe release on token `deinit`.

Files changed: `Tenney/AppModel.swift`, `Tenney/LearnTenneyPractice.swift`, `Tenney/LearnTenneyHubView.swift`.

### Testing
- No automated tests were run as part of this change.
- Manual smoke-test checklist (for reviewer):
  - Open the Tuner and confirm the utility bar shows the current tuner state.
  - Enter Learn → Tuner practice and verify the tuner remains active while the practice view is present.
  - Exit Learn and confirm the tuner state reflects the user toggle (no forced "Tuner off") and the utility bar text/icon update appropriately.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697346c6c324832789b49ed5b3d4fd81)