### PR TITLE
Add 'Learning Settings' Learn Tenney module with settings map and deep links

### DIFF
--- a/Tenney/LearnStepFactory.swift
+++ b/Tenney/LearnStepFactory.swift
@@ -169,6 +169,8 @@ enum LearnStepFactory {
                     validate: { $0 == .builderScopeTimedSatisfied }
                 )
             ]
+        case .learningSettings:
+            return []
         case .rootPitchTuningConfig:
             return []
         }

--- a/Tenney/LearnTenneyHubView.swift
+++ b/Tenney/LearnTenneyHubView.swift
@@ -14,7 +14,7 @@ enum LearnTenneyEntryPoint: Sendable {
 }
 
 enum LearnTenneyModule: String, CaseIterable, Identifiable, Sendable {
-    case lattice, tuner, builder, rootPitchTuningConfig
+    case lattice, tuner, builder, learningSettings, rootPitchTuningConfig
     var id: String { rawValue }
 
     var title: String {
@@ -22,6 +22,7 @@ enum LearnTenneyModule: String, CaseIterable, Identifiable, Sendable {
         case .lattice: return "Lattice"
         case .tuner:   return "Tuner"
         case .builder: return "Builder"
+        case .learningSettings: return "Learning Settings"
         case .rootPitchTuningConfig: return "Root Pitch & Tuning Configuration"
         }
     }
@@ -31,6 +32,7 @@ enum LearnTenneyModule: String, CaseIterable, Identifiable, Sendable {
         case .lattice: return "Selection, limits, axis shift, and auditioning"
         case .tuner:   return "Views, locks, confidence, limits, and stage mode"
         case .builder: return "Pads, root, and the oscilloscope"
+        case .learningSettings: return "Settings map + deep links"
         case .rootPitchTuningConfig: return "Root Hz, tonic naming, concert pitch, and troubleshooting"
         }
     }
@@ -40,6 +42,7 @@ enum LearnTenneyModule: String, CaseIterable, Identifiable, Sendable {
         case .lattice: return "dot.circle.and.hand.point.up.left.fill"
         case .tuner:   return "dial.high.fill"
         case .builder: return "pianokeys.inverse"
+        case .learningSettings: return "map.fill"
         case .rootPitchTuningConfig: return "tuningfork"
         }
     }
@@ -47,6 +50,8 @@ enum LearnTenneyModule: String, CaseIterable, Identifiable, Sendable {
     var supportsPractice: Bool {
         switch self {
         case .rootPitchTuningConfig:
+            return false
+        case .learningSettings:
             return false
         default:
             return true
@@ -61,6 +66,8 @@ enum LearnTenneyModule: String, CaseIterable, Identifiable, Sendable {
         switch self {
         case .rootPitchTuningConfig:
             return LearnReferenceTopic.allCases
+        case .learningSettings:
+            return []
         default:
             return []
         }

--- a/Tenney/LearnTenneyModuleView.swift
+++ b/Tenney/LearnTenneyModuleView.swift
@@ -63,7 +63,9 @@ struct LearnTenneyModuleView: View {
                         LearnTenneyPracticeView(module: module, focus: $practiceFocus)
                     }
                 case .reference:
-                    if module.referenceTopics.isEmpty {
+                    if module == .learningSettings {
+                        LearnTenneySettingsMapView()
+                    } else if module.referenceTopics.isEmpty {
                         LearnTenneyReferenceListView(module: module) { focus in
                             practiceFocus = focus
                             tab = .practice

--- a/Tenney/LearnTenneyReference.swift
+++ b/Tenney/LearnTenneyReference.swift
@@ -211,6 +211,8 @@ struct LearnTenneyReferenceListView: View {
             ]
         case .rootPitchTuningConfig:
             return []
+        case .learningSettings:
+            return []
         }
     }
 }

--- a/Tenney/LearnTenneySettingsMapView.swift
+++ b/Tenney/LearnTenneySettingsMapView.swift
@@ -1,0 +1,417 @@
+import SwiftUI
+
+private struct SettingsHotspot: Identifiable {
+    let id: String
+    let title: String
+    let subtitle: String?
+    let systemImage: String
+    let valuePills: [String]
+    let expandedRows: [String]
+    let openAction: () -> Void
+    let openLabel: String
+}
+
+struct LearnTenneySettingsMapView: View {
+    @EnvironmentObject private var app: AppModel
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @StateObject private var audioController = AudioSessionController.shared
+
+    @AppStorage(SettingsKeys.tonicNameMode) private var tonicNameModeRaw: String = TonicNameMode.auto.rawValue
+    @AppStorage(SettingsKeys.tonicE3) private var tonicE3: Int = 0
+    @AppStorage(SettingsKeys.accidentalPreference) private var accidentalPreferenceRaw: String = AccidentalPreference.auto.rawValue
+    @AppStorage(SettingsKeys.noteNameA4Hz) private var noteNameA4Hz: Double = 440
+    @AppStorage(SettingsKeys.staffA4Hz) private var concertA4Hz: Double = 440
+
+    @AppStorage(SettingsKeys.guidesOn) private var guidesOn: Bool = true
+    @AppStorage(SettingsKeys.latticeAlwaysRecenterOnQuit) private var latticeAlwaysRecenterOnQuit: Bool = false
+    @AppStorage(SettingsKeys.latticeSoundEnabled) private var latticeSoundEnabled: Bool = true
+    @AppStorage(SettingsKeys.latticeDefaultZoomPreset) private var latticeDefaultZoomPresetRaw: String = LatticeZoomPreset.close.rawValue
+    @AppStorage(SettingsKeys.tenneyDistanceMode) private var tenneyDistanceModeRaw: String = TenneyDistanceMode.breakdown.rawValue
+    @AppStorage(SettingsKeys.labelDensity) private var labelDensity: Double = 0.65
+
+    @AppStorage(SettingsKeys.lissaSnap) private var lissaSnapSmall: Bool = true
+    @AppStorage(SettingsKeys.lissaMaxDen) private var lissaMaxDen: Int = 24
+    @AppStorage(SettingsKeys.lissaDotMode) private var lissaDotMode: Bool = false
+    @AppStorage(SettingsKeys.lissaHalfLife) private var lissaHalfLife: Double = 0.6
+
+    @AppStorage(SettingsKeys.stageKeepAwake) private var stageKeepAwake: Bool = true
+    @AppStorage(SettingsKeys.stageMinimalUI) private var stageMinimalUI: Bool = false
+
+    @State private var expandedIDs = Set<String>()
+    @State private var showEverything = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                LearnGlassCard {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Learning Settings")
+                            .font(.title2.weight(.semibold))
+                        Text("Most power lives in a few panels—tap to open.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+
+                ForEach(hotspots) { hotspot in
+                    SettingsHotspotCard(
+                        hotspot: hotspot,
+                        isExpanded: expandedIDs.contains(hotspot.id)
+                    ) {
+                        toggleExpanded(hotspot.id)
+                    }
+                }
+
+                LearnGlassCard {
+                    DisclosureGroup("Show everything", isExpanded: $showEverything) {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Root Studio")
+                            Text("Lattice UI · View · Grid · Distance")
+                            Text("Oscilloscope · View · Trace · Persistence · Snapping")
+                            Text("Audio & I/O · Device · Tone · Envelope · Headroom")
+                            Text("Tuner · Stage Mode")
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.top, 4)
+                    }
+                    .font(.subheadline.weight(.semibold))
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+        }
+        .onAppear { audioController.refreshAll() }
+    }
+
+    private func toggleExpanded(_ id: String) {
+        let update = {
+            if expandedIDs.contains(id) {
+                expandedIDs.remove(id)
+            } else {
+                expandedIDs.insert(id)
+            }
+        }
+        if reduceMotion {
+            update()
+        } else {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                update()
+            }
+        }
+    }
+
+    private var hotspots: [SettingsHotspot] {
+        [
+            SettingsHotspot(
+                id: "root-naming",
+                title: "Root & Naming",
+                subtitle: "What note is 1/1?",
+                systemImage: "tuningfork",
+                valuePills: [
+                    "Tonic: \(tonicDisplayName)",
+                    "Root: \(formatHz(app.rootHz))"
+                ],
+                expandedRows: [
+                    "Tonic naming",
+                    "Current",
+                    "Suggested",
+                    "Manual",
+                    "Letter",
+                    "Accidental",
+                    "Preview"
+                ],
+                openAction: { openRootStudioSection("nameAs") },
+                openLabel: "Open Root & Naming settings"
+            ),
+            SettingsHotspot(
+                id: "concert-a4",
+                title: "Concert Pitch / A4",
+                subtitle: nil,
+                systemImage: "music.quarternote.3",
+                valuePills: [
+                    "A4: \(formatHz(concertA4Hz))"
+                ],
+                expandedRows: [
+                    "440",
+                    "442",
+                    "Custom",
+                    "A4"
+                ],
+                openAction: { openRootStudioTab("a4") },
+                openLabel: "Open Concert Pitch settings"
+            ),
+            SettingsHotspot(
+                id: "pro-audio",
+                title: "Pro Audio (Mic / Device)",
+                subtitle: "Mic device + tone shaping.",
+                systemImage: "waveform.and.mic",
+                valuePills: [
+                    "Input: \(inputDeviceName)"
+                ],
+                expandedRows: [
+                    "Routing",
+                    "Output",
+                    "Force Built-in Speaker",
+                    "Engine",
+                    "Diagnostics"
+                ],
+                openAction: { openSettings(.audio, audioPage: .device) },
+                openLabel: "Open Pro Audio Device settings"
+            ),
+            SettingsHotspot(
+                id: "lattice-view",
+                title: "Lattice Grid / View",
+                subtitle: nil,
+                systemImage: "square.grid.2x2",
+                valuePills: [
+                    "Axes: \(onOff(guidesOn)) · Recenter: \(onOff(latticeAlwaysRecenterOnQuit))",
+                    "Sound: \(onOff(latticeSoundEnabled)) · Zoom: \(zoomPresetTitle)"
+                ],
+                expandedRows: [
+                    "Axis",
+                    "Always Recenter",
+                    "Sound",
+                    "Zoom Preset",
+                    "Node Size",
+                    "Label Density",
+                    "Connection Mode"
+                ],
+                openAction: { openSettings(.lattice, latticePage: .view) },
+                openLabel: "Open Lattice View settings"
+            ),
+            SettingsHotspot(
+                id: "snapping",
+                title: "Snapping",
+                subtitle: "How the lattice ‘chooses’ ratios.",
+                systemImage: "number",
+                valuePills: [
+                    "Favor small closure: \(onOff(lissaSnapSmall))",
+                    "Max den: \(lissaMaxDen)"
+                ],
+                expandedRows: [
+                    "Favor small closure",
+                    "Max den"
+                ],
+                openAction: { openSettings(.oscilloscope, oscilloscopePage: .snapping) },
+                openLabel: "Open Snapping settings"
+            ),
+            SettingsHotspot(
+                id: "distance",
+                title: "Distance",
+                subtitle: "How closeness is measured.",
+                systemImage: "ruler",
+                valuePills: [
+                    "Distance: \(distanceModeTitle)",
+                    "Cents ticks: \(onOff(centsTickLabelsOn))"
+                ],
+                expandedRows: [
+                    "Off",
+                    "Total",
+                    "Total + Breakdown"
+                ],
+                openAction: { openSettings(.lattice, latticePage: .distance) },
+                openLabel: "Open Distance settings"
+            ),
+            SettingsHotspot(
+                id: "scope-trace",
+                title: "Scope / Trace / Persistence",
+                subtitle: nil,
+                systemImage: "waveform.path.ecg",
+                valuePills: [
+                    "Trace: \(traceModeLabel)",
+                    "Half-life: \(formatHalfLife(lissaHalfLife))"
+                ],
+                expandedRows: [
+                    "Ribbon Width",
+                    "Dots",
+                    "Live Samples",
+                    "Alpha",
+                    "Persistence",
+                    "Half-life"
+                ],
+                openAction: { openSettings(.oscilloscope, oscilloscopePage: .trace) },
+                openLabel: "Open Scope settings"
+            ),
+            SettingsHotspot(
+                id: "stage-display",
+                title: "Stage / Display",
+                subtitle: nil,
+                systemImage: "rectangle.on.rectangle.angled",
+                valuePills: [
+                    "Keep awake: \(onOff(stageKeepAwake))",
+                    "Minimal UI: \(onOff(stageMinimalUI))"
+                ],
+                expandedRows: [
+                    "Stage dimmer",
+                    "Dim level",
+                    "Accent color",
+                    "Hide status bar",
+                    "Keep screen awake",
+                    "Minimal UI"
+                ],
+                openAction: { openSettings(.tuner) },
+                openLabel: "Open Stage display settings"
+            )
+        ]
+    }
+
+    private var tonicDisplayName: String {
+        let mode = TonicNameMode(rawValue: tonicNameModeRaw) ?? .auto
+        let preference = AccidentalPreference(rawValue: accidentalPreferenceRaw) ?? .auto
+        switch mode {
+        case .manual:
+            return TonicSpelling(e3: tonicE3).displayText
+        case .auto:
+            return TonicSpelling.from(
+                rootHz: app.rootHz,
+                noteNameA4Hz: noteNameA4Hz,
+                preference: preference
+            )?.displayText ?? TonicSpelling(e3: tonicE3).displayText
+        }
+    }
+
+    private var inputDeviceName: String {
+        if let selected = audioController.availableInputs.first(where: { $0.uid == audioController.selectedInputUID }) {
+            return selected.portName
+        }
+        return audioController.availableInputs.first?.portName ?? "System"
+    }
+
+    private var zoomPresetTitle: String {
+        LatticeZoomPreset(rawValue: latticeDefaultZoomPresetRaw)?.title ?? "Standard"
+    }
+
+    private var distanceModeTitle: String {
+        TenneyDistanceMode(rawValue: tenneyDistanceModeRaw)?.title ?? "Total"
+    }
+
+    private var centsTickLabelsOn: Bool {
+        labelDensity > 0.01
+    }
+
+    private var traceModeLabel: String {
+        lissaDotMode ? "Dots" : "Ribbon"
+    }
+
+    private func openRootStudioTab(_ tabRaw: String) {
+        NotificationCenter.default.post(name: .requestRootStudioTab, object: tabRaw)
+    }
+
+    private func openRootStudioSection(_ section: String) {
+        NotificationCenter.default.post(name: .requestRootStudioSection, object: section)
+    }
+
+    private func openSettings(
+        _ category: StudioConsoleView.SettingsCategory,
+        latticePage: SettingsDeepLinkLatticePage? = nil,
+        oscilloscopePage: SettingsDeepLinkOscilloscopePage? = nil,
+        audioPage: SettingsDeepLinkAudioPage? = nil
+    ) {
+        SettingsDeepLinkCenter.shared.open(
+            SettingsDeepLink(
+                category: category,
+                latticePage: latticePage,
+                oscilloscopePage: oscilloscopePage,
+                audioPage: audioPage
+            )
+        )
+    }
+
+    private func formatHz(_ value: Double) -> String {
+        if value.rounded(.down) == value {
+            return "\(Int(value)) Hz"
+        }
+        return String(format: "%.1f Hz", value)
+    }
+
+    private func formatHalfLife(_ value: Double) -> String {
+        String(format: "%.2fs", value)
+    }
+
+    private func onOff(_ v: Bool) -> String { v ? "On" : "Off" }
+}
+
+private struct SettingsHotspotCard: View {
+    let hotspot: SettingsHotspot
+    let isExpanded: Bool
+    let toggleExpanded: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        LearnGlassCard {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top, spacing: 12) {
+                    Image(systemName: hotspot.systemImage)
+                        .font(.title3.weight(.semibold))
+                        .frame(width: 28)
+                        .foregroundStyle(.tint)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(hotspot.title)
+                            .font(.headline)
+                        if let subtitle = hotspot.subtitle {
+                            Text(subtitle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+
+                        if !hotspot.valuePills.isEmpty {
+                            HStack(spacing: 6) {
+                                ForEach(hotspot.valuePills, id: \.self) { pill in
+                                    Text(pill)
+                                        .font(.caption2.weight(.semibold))
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                        .padding(.horizontal, 8)
+                                        .padding(.vertical, 4)
+                                        .background(.thinMaterial, in: Capsule())
+                                }
+                            }
+                        }
+                    }
+
+                    Spacer()
+
+                    Button(action: hotspot.openAction) {
+                        Text("Open")
+                            .font(.caption.weight(.semibold))
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .modifier(GlassRoundedRect(corner: 12))
+                    }
+                    .buttonStyle(GlassPressFeedback())
+                    .accessibilityLabel(Text(hotspot.openLabel))
+                }
+
+                if !hotspot.expandedRows.isEmpty {
+                    Button(action: toggleExpanded) {
+                        HStack(spacing: 6) {
+                            Text("What’s inside")
+                                .font(.caption.weight(.semibold))
+                            Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(Text(isExpanded ? "Hide what's inside" : "Show what's inside"))
+
+                    if isExpanded {
+                        VStack(alignment: .leading, spacing: 4) {
+                            ForEach(hotspot.expandedRows, id: \.self) { row in
+                                Text(row)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .top)))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tenney/LearnTenneyTour.swift
+++ b/Tenney/LearnTenneyTour.swift
@@ -114,6 +114,7 @@ struct LearnTenneyTourView: View {
         case .lattice: latticeDone = true
         case .tuner: tunerDone = true
         case .builder: builderDone = true
+        case .learningSettings: break
         case .rootPitchTuningConfig: break
         }
     }
@@ -266,6 +267,8 @@ struct LearnTenneyTourView: View {
                     tryIt: "Make two tones interact (or use pads) and watch the shape evolve."
                 )
             ]
+        case .learningSettings:
+            return []
         case .rootPitchTuningConfig:
             return []
         }

--- a/Tenney/SettingsDeepLink.swift
+++ b/Tenney/SettingsDeepLink.swift
@@ -1,0 +1,39 @@
+import Combine
+import Foundation
+
+struct SettingsDeepLink: Equatable {
+    let category: StudioConsoleView.SettingsCategory
+    var latticePage: SettingsDeepLinkLatticePage? = nil
+    var oscilloscopePage: SettingsDeepLinkOscilloscopePage? = nil
+    var audioPage: SettingsDeepLinkAudioPage? = nil
+}
+
+enum SettingsDeepLinkLatticePage: String, Equatable {
+    case view
+    case grid
+    case distance
+}
+
+enum SettingsDeepLinkOscilloscopePage: String, Equatable {
+    case view
+    case trace
+    case persistence
+    case snapping
+}
+
+enum SettingsDeepLinkAudioPage: String, Equatable {
+    case device
+    case tone
+    case envelope
+    case headroom
+}
+
+@MainActor
+final class SettingsDeepLinkCenter: ObservableObject {
+    static let shared = SettingsDeepLinkCenter()
+    @Published var pending: SettingsDeepLink? = nil
+
+    func open(_ link: SettingsDeepLink) {
+        pending = link
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, reference-only “Learning Settings” module that surfaces important configurable panels as a compact settings map with current-value pills and direct deep links to the exact in-app settings surfaces.
- Keep the module content-light, reuse existing glass UI components, and avoid adding new modal layers or changing tuner/audio routing behavior.

### Description
- Implemented a settings deep-link model and center via `SettingsDeepLink` / `SettingsDeepLinkCenter` and wired a consumer path so the app can open the `StudioConsoleView` to a category and pre-select a page (`lattice`, `oscilloscope`, `audio`) using initial-page parameters; ContentView now listens for these deep-link requests and the Root Studio accepts section/tab requests via notifications like `requestRootStudioTab` and `requestRootStudioSection` (handlers trigger the existing `RootStudioSheet` behavior). 
- Added a new reference-only Learn Tenney view `LearnTenneySettingsMapView` that renders compact hotspot cards (title, one-line subtitle, current-value chips, glass `Open` CTA, and a collapsible `What’s inside` list) and issues deep-link requests rather than creating new sheets. 
- Registered the module in the Learn Tenney system by adding `learningSettings` to `LearnTenneyModule` and wiring it into `LearnTenneyModuleView` so the Reference tab shows the new `LearnTenneySettingsMapView` (the module is reference-only and has no practice steps). 
- Hotspot deep-link mapping (for review): Root & Naming → Root Studio `nameAs` section; Concert Pitch / A4 → Root Studio `a4` tab; Pro Audio → `StudioConsoleView` category `.audio` on `device` page; Lattice Grid / View → `StudioConsoleView` category `.lattice` on `view` page; Snapping → `.oscilloscope` on `snapping` page; Distance → `.lattice` on `distance` page; Scope/Trace/Persistence → `.oscilloscope` on `trace` page; Stage/Display → `.tuner` (Stage Mode section). 
- Key modified/added files: `Tenney/LearnTenneySettingsMapView.swift` (new), `Tenney/SettingsDeepLink.swift` (new), `Tenney/Settings.swift` (deep-link plumbing + initialPage passthroughs), `Tenney/ContentView.swift` (Root Studio + deep-link handlers), `Tenney/LearnTenneyHubView.swift` and `Tenney/LearnTenneyModuleView.swift` (module registration and display), plus small patches to `LearnStepFactory`, `LearnTenneyReference`, and `LearnTenneyTour` to treat the new module as reference-only. 

### Testing
- Automated tests: none were executed for this change (no CI/unit runs were requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69734b46cd5c8327ab96439616bdb069)