### PR TITLE
Add Learn Tenney “Library & Packs” reference-only module

### DIFF
--- a/Tenney/AppModel.swift
+++ b/Tenney/AppModel.swift
@@ -178,6 +178,7 @@ final class AppModel: ObservableObject {
     enum ScaleLibraryLaunchMode: Equatable {
         case recents
         case favorites
+        case communityPacks
     }
 
     @Published var scaleLibraryLaunchMode: ScaleLibraryLaunchMode? = nil

--- a/Tenney/LearnOverlay.swift
+++ b/Tenney/LearnOverlay.swift
@@ -295,6 +295,7 @@ private struct LearnCompletionView: View {
         case .lattice: return "Lattice is ready."
         case .tuner: return "Tuner is ready."
         case .builder: return "Builder is ready."
+        case .libraryPacks: return "Library & Packs is ready."
         case .rootPitchTuningConfig: return "Reference is ready."
         }
     }
@@ -307,6 +308,8 @@ private struct LearnCompletionView: View {
             return ["Switch views", "Use lock", "Use stage mode"]
         case .builder:
             return ["Play pads", "Add root", "Hear blends"]
+        case .libraryPacks:
+            return ["Open your library", "Browse packs", "Learn community packs"]
         case .rootPitchTuningConfig:
             return ["Review root vs tonic", "Check concert pitch", "Debug labels"]
         }

--- a/Tenney/LearnStepFactory.swift
+++ b/Tenney/LearnStepFactory.swift
@@ -169,6 +169,8 @@ enum LearnStepFactory {
                     validate: { $0 == .builderScopeTimedSatisfied }
                 )
             ]
+        case .libraryPacks:
+            return []
         case .rootPitchTuningConfig:
             return []
         }

--- a/Tenney/LearnTenneyHubView.swift
+++ b/Tenney/LearnTenneyHubView.swift
@@ -14,7 +14,7 @@ enum LearnTenneyEntryPoint: Sendable {
 }
 
 enum LearnTenneyModule: String, CaseIterable, Identifiable, Sendable {
-    case lattice, tuner, builder, rootPitchTuningConfig
+    case lattice, tuner, builder, libraryPacks, rootPitchTuningConfig
     var id: String { rawValue }
 
     var title: String {
@@ -22,6 +22,7 @@ enum LearnTenneyModule: String, CaseIterable, Identifiable, Sendable {
         case .lattice: return "Lattice"
         case .tuner:   return "Tuner"
         case .builder: return "Builder"
+        case .libraryPacks: return "Library & Packs"
         case .rootPitchTuningConfig: return "Root Pitch & Tuning Configuration"
         }
     }
@@ -31,6 +32,7 @@ enum LearnTenneyModule: String, CaseIterable, Identifiable, Sendable {
         case .lattice: return "Selection, limits, axis shift, and auditioning"
         case .tuner:   return "Views, locks, confidence, limits, and stage mode"
         case .builder: return "Pads, root, and the oscilloscope"
+        case .libraryPacks: return "Library basics, tags, favorites, and community packs"
         case .rootPitchTuningConfig: return "Root Hz, tonic naming, concert pitch, and troubleshooting"
         }
     }
@@ -40,12 +42,15 @@ enum LearnTenneyModule: String, CaseIterable, Identifiable, Sendable {
         case .lattice: return "dot.circle.and.hand.point.up.left.fill"
         case .tuner:   return "dial.high.fill"
         case .builder: return "pianokeys.inverse"
+        case .libraryPacks: return "tray.fill"
         case .rootPitchTuningConfig: return "tuningfork"
         }
     }
 
     var supportsPractice: Bool {
         switch self {
+        case .libraryPacks:
+            return false
         case .rootPitchTuningConfig:
             return false
         default:

--- a/Tenney/LearnTenneyModuleView.swift
+++ b/Tenney/LearnTenneyModuleView.swift
@@ -63,7 +63,9 @@ struct LearnTenneyModuleView: View {
                         LearnTenneyPracticeView(module: module, focus: $practiceFocus)
                     }
                 case .reference:
-                    if module.referenceTopics.isEmpty {
+                    if module == .libraryPacks {
+                        LearnTenneyLibraryPacksReferenceView()
+                    } else if module.referenceTopics.isEmpty {
                         LearnTenneyReferenceListView(module: module) { focus in
                             practiceFocus = focus
                             tab = .practice

--- a/Tenney/LearnTenneyPractice.swift
+++ b/Tenney/LearnTenneyPractice.swift
@@ -180,6 +180,9 @@ private struct PracticeContent: View {
             case .builder:
                 BuilderPracticeHost()
 
+            case .libraryPacks:
+                EmptyView()
+
             case .rootPitchTuningConfig:
                 EmptyView()
             }

--- a/Tenney/LearnTenneyReference.swift
+++ b/Tenney/LearnTenneyReference.swift
@@ -209,6 +209,8 @@ struct LearnTenneyReferenceListView: View {
                     focus: .builderOscilloscope
                 )
             ]
+        case .libraryPacks:
+            return []
         case .rootPitchTuningConfig:
             return []
         }

--- a/Tenney/LearnTenneyReferenceSeries.swift
+++ b/Tenney/LearnTenneyReferenceSeries.swift
@@ -84,6 +84,103 @@ struct LearnTenneyReferenceTopicView: View {
     }
 }
 
+struct LearnTenneyLibraryPacksReferenceView: View {
+    @EnvironmentObject private var app: AppModel
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                LearnReferenceCard(
+                    title: "What the Library is",
+                    bullets: [
+                        "Library = your scales collection.",
+                        "Packs are folders/collections that organize scales.",
+                        "Tags + Favorites help you retrieve fast."
+                    ],
+                    actions: [
+                        .init(title: "Open Library", isProminent: true, action: openLibrary)
+                    ]
+                )
+
+                LearnReferenceCard(
+                    title: "Packs (Folders)",
+                    bullets: [
+                        "Packs group scales by idea, tuning, or project.",
+                        "Installing a pack adds its scales to the Library.",
+                        "Access packs from the Library or the Community Packs page.",
+                        "Keep personal packs separate from curated Community Packs."
+                    ],
+                    actions: [
+                        .init(title: "Open Packs", isProminent: false, action: openLibrary)
+                    ]
+                )
+
+                LearnReferenceCard(
+                    title: "Tags & Favorites",
+                    bullets: [
+                        "Favorites = quick shortlist.",
+                        "Tags = cross-cutting organization (genre, limit, source).",
+                        "Combine tags + search to find scales fast."
+                    ],
+                    actions: []
+                )
+
+                LearnReferenceCard(
+                    title: "Import / Export",
+                    bullets: [
+                        "Import brings scale files or packs into your Library.",
+                        "Export shares scales/packs as .scl / .kbm (and more).",
+                        "Exports don’t delete your originals."
+                    ],
+                    actions: []
+                )
+
+                LearnReferenceCard(
+                    title: "Community Packs (Curated)",
+                    bullets: [
+                        "Curated/verified packs from Tenney devs + community contributors.",
+                        "Fetched from the internet (connection required).",
+                        "Installing adds a pack to your Library like any other pack."
+                    ],
+                    actions: [
+                        .init(title: "Browse Community Packs", isProminent: true, action: openCommunityPacks)
+                    ]
+                )
+
+                LearnReferenceCard(
+                    title: "Submit a Community Pack",
+                    bullets: [
+                        "Want to contribute? Follow the submission process.",
+                        "Every pack is curated/verified before listing."
+                    ],
+                    actions: [
+                        .init(title: "How to Submit", isProminent: false, action: openSubmission)
+                    ]
+                )
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+        }
+        .navigationTitle("Library & Packs")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func openLibrary() {
+        app.scaleLibraryLaunchMode = .recents
+        app.showScaleLibraryDetent = true
+    }
+
+    private func openCommunityPacks() {
+        app.scaleLibraryLaunchMode = .communityPacks
+        app.showScaleLibraryDetent = true
+    }
+
+    private func openSubmission() {
+        openURL(CommunityPacksEndpoints.issuesURL)
+    }
+}
+
 private struct RootTonicConcertReferenceView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -308,6 +405,43 @@ private struct LearnSummaryCard: View {
                 Text(title)
                     .font(.headline)
                 BulletList(items: bullets)
+            }
+        }
+    }
+}
+
+private struct LearnReferenceAction {
+    let title: String
+    let isProminent: Bool
+    let action: () -> Void
+}
+
+private struct LearnReferenceCard: View {
+    let title: String
+    let bullets: [String]
+    let actions: [LearnReferenceAction]
+
+    var body: some View {
+        LearnGlassCard {
+            VStack(alignment: .leading, spacing: 10) {
+                Text(title)
+                    .font(.headline)
+                BulletList(items: bullets)
+
+                if !actions.isEmpty {
+                    HStack(spacing: 10) {
+                        ForEach(actions.indices, id: \.self) { idx in
+                            let action = actions[idx]
+                            Button {
+                                action.action()
+                            } label: {
+                                Text(action.title)
+                                    .frame(maxWidth: .infinity, minHeight: 36)
+                            }
+                            .buttonStyle(action.isProminent ? .borderedProminent : .bordered)
+                        }
+                    }
+                }
             }
         }
     }

--- a/Tenney/LearnTenneyTour.swift
+++ b/Tenney/LearnTenneyTour.swift
@@ -114,6 +114,7 @@ struct LearnTenneyTourView: View {
         case .lattice: latticeDone = true
         case .tuner: tunerDone = true
         case .builder: builderDone = true
+        case .libraryPacks: break
         case .rootPitchTuningConfig: break
         }
     }
@@ -266,6 +267,8 @@ struct LearnTenneyTourView: View {
                     tryIt: "Make two tones interact (or use pads) and watch the shape evolve."
                 )
             ]
+        case .libraryPacks:
+            return []
         case .rootPitchTuningConfig:
             return []
         }

--- a/Tenney/ScaleLibrarySheet.swift
+++ b/Tenney/ScaleLibrarySheet.swift
@@ -285,14 +285,18 @@ struct ScaleLibrarySheet: View {
             // consume it so it’s one-shot
             model.scaleLibraryLaunchMode = nil
 
-            libraryPage = 0
             library.sortKey = .recent
 
             switch mode {
             case .recents:
+                libraryPage = 0
                 libraryFavoritesOnly = false
             case .favorites:
+                libraryPage = 0
                 libraryFavoritesOnly = true
+            case .communityPacks:
+                libraryPage = 2
+                libraryFavoritesOnly = false
             }
         }
         .onChange(of: filters) { _ in


### PR DESCRIPTION
### Motivation
- Provide a top-level Learn Tenney reference module that explains Library, Packs, Tags/Favorites, Import/Export, and Community Packs with minimal, linear, and VoiceOver-friendly copy and deep links into existing Library/Community screens.

### Description
- Add a new `LearnTenneyModule` case `libraryPacks` with title/subtitle/system image and mark it reference-only by returning `false` from `supportsPractice` for that case (`Tenney/LearnTenneyHubView.swift`).
- Implement a new reference view `LearnTenneyLibraryPacksReferenceView` that presents 6 succinct reference cards (What the Library is; Packs; Tags & Favorites; Import / Export; Community Packs; Submit a Community Pack) using a new small helper `LearnReferenceCard` and associated `LearnReferenceAction` (`Tenney/LearnTenneyReferenceSeries.swift`).
- Wire the module into the Learn UI so the new module appears alongside other modules and its reference view is shown when selected (`Tenney/LearnTenneyModuleView.swift`, `Tenney/LearnTenneyReference.swift`, `Tenney/LearnStepFactory.swift`, `Tenney/LearnTenneyPractice.swift`, `Tenney/LearnTenneyTour.swift`, `Tenney/LearnOverlay.swift`).
- Add deep-link actions that reuse existing navigation entry points by toggling `AppModel` launch state (`app.scaleLibraryLaunchMode` + `app.showScaleLibraryDetent`) to open the Library detent in either the default library or the Community Packs page, and add a `communityPacks` launch mode (`Tenney/LearnTenneyReferenceSeries.swift`, `Tenney/AppModel.swift`, `Tenney/ScaleLibrarySheet.swift`).
- Keep copy and layout minimal, linear, and consistent with existing Learn Tenney reference card patterns; no new flows or new data-counting logic introduced.

### Testing
- No automated tests were executed for this change.
- Changes were limited to UI wiring and reference copy and were committed after patching; acceptance checks (manual) expected: the new tile appears in Learn, the reference screen shows 6 concise cards and deep-links open the Library and Community Packs views via the existing `ScaleLibrarySheet` detent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973554f5800832799c1ff8d8d757c53)