### PR TITLE
Fix Learn Tenney deep links and expand Library & Packs lesson

### DIFF
--- a/Tenney/LearnTenneyDeepLink.swift
+++ b/Tenney/LearnTenneyDeepLink.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum LearnTenneyDeepLinkDestination: String, Sendable {
+    case libraryHome
+    case communityPacks
+    case builderHome
+    case communityPackSubmission
+
+    static func from(_ notification: Notification) -> LearnTenneyDeepLinkDestination? {
+        guard let raw = notification.userInfo?[LearnTenneyDeepLinkPayload.destinationKey] as? String else { return nil }
+        return LearnTenneyDeepLinkDestination(rawValue: raw)
+    }
+}
+
+enum LearnTenneyDeepLinkPayload {
+    static let destinationKey = "destination"
+}
+
+extension Notification.Name {
+    static let tenneyLearnDeepLink = Notification.Name("tenney.learn.deepLink")
+}


### PR DESCRIPTION
### Motivation
- Deep-link CTAs in the Learn Tenney "Library & Packs" reference were no-ops because navigation was attempted from the sheet that was dismissed; routing must occur from an always-alive owner after dismissal. 
- The existing "Import / Export" lesson was too minimal and needed a fuller, still-reference-only, "Make + Save + Store + Export" lesson that maps the Builder→Library→Export workflow.

### Description
- Added `Tenney/LearnTenneyDeepLink.swift` which defines `Notification.Name.tenneyLearnDeepLink`, a `LearnTenneyDeepLinkDestination` enum, and a small payload key constant to standardize deep-link requests. 
- Wired a single always-alive handler into `ContentView` that listens for `tenneyLearnDeepLink` and performs routing after a short async delay using existing app APIs (sets `app.scaleLibraryLaunchMode` + `app.showScaleLibraryDetent`, creates an empty `ScaleBuilderPayload` to open Builder, or calls `openURL` for submission), and emits diagnostics breadcrumbs via `DiagnosticsCenter`/`SentryService`. 
- Reworked `Tenney/LearnTenneyReferenceSeries.swift` to: rename the lesson to `Make, Save, Store, Export` and expand its copy into intro, `Workflow`, `Where things live`, and `Export` sections; replace the minimal content with the new reference card and add two CTAs (`Open Builder`, `Open Library`). 
- Replaced the old sheet-scoped deep-link scheduling with a safe pattern: lesson CTA buttons now `post` the `tenneyLearnDeepLink` notification and then `dismiss()` the sheet (via `requestDeepLink`), and a shared `LearnReferenceActionsRow` helper renders the glass-styled CTA buttons to preserve existing visual/accessibility style.

### Testing
- Automated tests: none were run. 
- The change was committed and contains localized diffs only in `ContentView.swift`, `LearnTenneyReferenceSeries.swift`, and the new `LearnTenneyDeepLink.swift` file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697360926e0c83278302f1f0fa6ee8c7)