### PR TITLE
Replace waveform tile assets with SF Symbols

### DIFF
--- a/Tenney/Settings.swift
+++ b/Tenney/Settings.swift
@@ -4468,43 +4468,6 @@ private struct GlassNavTile<Destination: View>: View {
     }
 
 
-    // MARK: Wave options + preview tile
-    // Inside StudioConsoleView
-    private static func previewWaveY(_ kind: ToneOutputEngine.GlobalWave, x: CGFloat) -> CGFloat {
-        let t = x - floor(x)
-        switch kind {
-        case .foldedSine: return (abs(sin(2 * .pi * t)) * 2) - 1
-        case .triangle:   return 1 - abs((t * 4).truncatingRemainder(dividingBy: 4) - 2)
-        case .saw:        return (t * 2) - 1
-        default:          return sin(2 * .pi * t)
-        }
-    }
-
-
-    fileprivate struct WavePreview: View {
-        let kind: ToneOutputEngine.GlobalWave
-        var body: some View {
-            GeometryReader { geo in
-                let w = geo.size.width, h = geo.size.height
-                let mid = h / 2
-                let amp = h * 0.36
-                Canvas { ctx, size in
-                    var p = Path()
-                    let samples = max(24, Int(size.width))
-                    for i in 0...samples {
-                        let x01 = CGFloat(i) / CGFloat(samples)
-                        let y01 = previewWaveY(kind, x: x01)   // ✅ now visible here
-                        let px  = x01 * w
-                        let py  = mid - (y01 * amp)
-                        if i == 0 { p.move(to: .init(x: px, y: py)) }
-                        else      { p.addLine(to: .init(x: px, y: py)) }
-                    }
-                    ctx.stroke(p, with: .color(.primary.opacity(0.85)), lineWidth: 6)
-                }
-            }
-        }
-    }
-
     fileprivate struct WaveTile: View {
         @Environment(\.tenneyTheme) private var theme: ResolvedTenneyTheme
         @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
@@ -4521,7 +4484,8 @@ private struct GlassNavTile<Destination: View>: View {
                     ZStack(alignment: .topTrailing) {
                         if #available(iOS 26.0, *) {
                             GlassEffectContainer {
-                                WavePreview(kind: option.wave)
+                                WaveformIcon(waveform: option.wave)
+                                    .accessibilityHidden(true)
                                     .padding(10)
                                     .frame(minWidth: 120, minHeight: 64)
                                     .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
@@ -4541,7 +4505,8 @@ private struct GlassNavTile<Destination: View>: View {
                             RoundedRectangle(cornerRadius: 12, style: .continuous)
                                 .fill(.ultraThinMaterial)
                                 .overlay(
-                                    WavePreview(kind: option.wave)
+                                    WaveformIcon(waveform: option.wave)
+                                        .accessibilityHidden(true)
                                         .padding(10)
                                         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                                 )
@@ -4570,6 +4535,7 @@ private struct GlassNavTile<Destination: View>: View {
                     }
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel(WaveformSymbol.a11yLabel(for: option.wave))
 
 
                 // Label OUTSIDE the button, secondary
@@ -4577,6 +4543,7 @@ private struct GlassNavTile<Destination: View>: View {
                     .font(.caption2.weight(selected ? .semibold : .regular))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
+                    .accessibilityHidden(true)
             }
             .contentTransition(.opacity)
         }

--- a/Tenney/WaveformIcon.swift
+++ b/Tenney/WaveformIcon.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+enum WaveformSymbol {
+    static func systemName(for waveform: ToneOutputEngine.GlobalWave) -> String {
+        if #available(iOS 17.0, macOS 14.0, *) {
+            switch waveform {
+            case .foldedSine:
+                return "waveform"
+            case .triangle:
+                return "triangleshape"
+            case .saw:
+                return "righttriangle"
+            @unknown default:
+                return "waveform"
+            }
+        }
+
+        return "waveform"
+    }
+
+    static func a11yLabel(for waveform: ToneOutputEngine.GlobalWave) -> String {
+        switch waveform {
+        case .foldedSine:
+            return "Folded sine wave"
+        case .triangle:
+            return "Triangle wave"
+        case .saw:
+            return "Saw wave"
+        @unknown default:
+            return "Waveform"
+        }
+    }
+}
+
+struct WaveformIcon: View {
+    let waveform: ToneOutputEngine.GlobalWave
+
+    @Environment(\.colorScheme) private var scheme
+
+    private let slot: CGFloat = 26
+
+    var body: some View {
+        Image(systemName: WaveformSymbol.systemName(for: waveform))
+            .font(.system(size: 18, weight: .semibold))
+            .symbolRenderingMode(.monochrome)
+            .foregroundStyle(scheme == .dark ? Color.black : Color.primary)
+            .frame(width: slot, height: slot, alignment: .center)
+            .accessibilityLabel(WaveformSymbol.a11yLabel(for: waveform))
+    }
+}


### PR DESCRIPTION
### Motivation
- Replace bitmap waveform assets in the audio waveform tiles with SF Symbols to remove image assets while preserving tile layout and accessibility.
- Centralize the mapping from the app waveform enum to a symbol name so each tile uses the same source of truth and is safe across OS versions.

### Description
- Added `Tenney/WaveformIcon.swift` which provides `WaveformSymbol.systemName(for:)`, `WaveformSymbol.a11yLabel(for:)`, and `WaveformIcon: View` that renders the mapped SF Symbol in a fixed `slot` (`26`) using `.font(.system(size:18,.semibold))`, `.symbolRenderingMode(.monochrome)`, an availability guard (`if #available(iOS 17.0, macOS 14.0, *)`) and a fallback to `waveform` for older OSes.
- Replaced the previous waveform rendering inside the waveform tiles (`WaveTile` in `Tenney/Settings.swift`) with `WaveformIcon(waveform:)`, preserving the existing `.padding(10)`, `.frame(minWidth: 120, minHeight: 64)`, clipping, and selection checkmark so there is no tile layout churn.
- Ensured styling safety by applying `.foregroundStyle(scheme == .dark ? Color.black : Color.primary)` on the symbol image itself to avoid white-on-white in dark mode for light/glass tile backgrounds.
- Implemented accessibility by adding an explicit label via `WaveformSymbol.a11yLabel(for:)` on the tile and marking the decorative icon and text as hidden from VoiceOver to avoid duplicate chatter.

### Testing
- Ran repository searches (`rg`) to confirm waveform assets are no longer referenced by the waveform tiles and to locate relevant code paths, and the search results indicate the tiles now use `WaveformIcon` (passed).
- Confirmed changes are limited to `Tenney/WaveformIcon.swift` (new) and `Tenney/Settings.swift` (wave tile swap) with no other asset removals or edits (passed).
- No unit or UI test suites were executed in this patch (none run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973686efadc8327b2df0f6de286db04)