### PR TITLE
Fix dark-mode ink for GlassWhiteCircle icons

### DIFF
--- a/Tenney/CommunityPacksViews.swift
+++ b/Tenney/CommunityPacksViews.swift
@@ -1175,16 +1175,11 @@ private struct CommunityPackDetailView: View {
 
             Spacer()
 
-            Button(action: handleCloseTap) {
-                Image(systemName: isSelecting ? "chevron.backward" : "checkmark")
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundStyle(.primary)
-                    .frame(width: 44, height: 44)
-                    .modifier(GlassWhiteCircle())
-                    .contentShape(Circle())
-                    .accessibilityLabel(isSelecting ? "Back" : "Close")
-            }
-            .buttonStyle(.plain)
+            GlassWhiteCircleIconButton(
+                systemName: isSelecting ? "chevron.backward" : "checkmark",
+                accessibilityLabel: isSelecting ? "Back" : "Close",
+                action: handleCloseTap
+            )
         }
         .padding(.horizontal, 16)
         .padding(.top, 10)

--- a/Tenney/GlassWhiteCircle.swift
+++ b/Tenney/GlassWhiteCircle.swift
@@ -98,6 +98,35 @@ public struct GlassWhiteCircle: ViewModifier {
             .shadow(color: .black.opacity(0.18), radius: 10, x: 0, y: 6)
     }
 }
+
+struct GlassWhiteCircleIconButton: View {
+    let systemName: String
+    let accessibilityLabel: String
+    let action: () -> Void
+    var size: CGFloat = 44
+    var font: Font = .system(size: 16, weight: .semibold)
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var ink: Color {
+        colorScheme == .dark ? .black : .primary
+    }
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .symbolRenderingMode(.monochrome)
+                .foregroundStyle(ink)
+                .font(font)
+                .frame(width: size, height: size)
+                .modifier(GlassWhiteCircle())
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .tint(ink)
+        .accessibilityLabel(Text(accessibilityLabel))
+    }
+}
 public struct GlassRedRoundedRect: ViewModifier {
     
     let corner: CGFloat

--- a/Tenney/Settings.swift
+++ b/Tenney/Settings.swift
@@ -2729,16 +2729,13 @@ struct StudioConsoleView: View {
                 }
                 .overlay(alignment: .topLeading) {
                     if activeCategory != nil {
-                        Button {
-                            withAnimation(catAnim) { activeCategory = nil }
-                        } label: {
-                            Image(systemName: "chevron.backward")
-                                .font(.headline.weight(.semibold))
-                                .frame(width: 40, height: 40)
-                                .glassWhiteCircle()      // ⬅️ MOVE HERE
-                                .contentShape(Circle())
-                        }
-                        .buttonStyle(.plain)
+                        GlassWhiteCircleIconButton(
+                            systemName: "chevron.backward",
+                            accessibilityLabel: "Back",
+                            action: { withAnimation(catAnim) { activeCategory = nil } },
+                            size: 40,
+                            font: .headline.weight(.semibold)
+                        )
                         .padding(.top, 20)
                         .padding(.leading, 20)
                         .transition(.opacity)


### PR DESCRIPTION
### Motivation
- White SF Symbols rendered on `GlassWhiteCircle` surfaces became invisible in dark mode because the glyph color resolved to white, so white-on-white controls (back chevrons and a checkmark) were unreadable.
- The Learn Tenney back button already handled readable ink correctly, so the fix canonicalizes that behavior into a shared component for minimal, localized changes.

### Description
- Add a shared `GlassWhiteCircleIconButton` view in `Tenney/GlassWhiteCircle.swift` that computes `ink` from `@Environment(\.colorScheme)` and applies it via `.tint(ink)` on the `Button` and `.symbolRenderingMode(.monochrome)` + `.foregroundStyle(ink)` on the `Image` to cover both toolbar and in-view contexts.
- Replace the settings sub-sheet overlay back chevron with `GlassWhiteCircleIconButton` in `Tenney/Settings.swift` to ensure readable ink on white glass surfaces.
- Replace the Community Packs detail top-bar button (checkmark / chevron) with `GlassWhiteCircleIconButton` in `Tenney/CommunityPacksViews.swift` so the checkmark is visible in dark mode.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69736c092eec8327815461d94c48c936)