### PR TITLE
Use HEJI2 fonts + mapping for accidentals (text, staff, lattice, tuner)

### DIFF
--- a/Tenney/DevOverlay.swift
+++ b/Tenney/DevOverlay.swift
@@ -61,7 +61,7 @@ struct DevOverlay: ViewModifier {
                     Text("FPS \(counter.fps)")
                     Text("Therm \(thermal.rawValue)")
                     Text("RT \(reduceTrans ? "on" : "off")")
-                    Text("Ctr \(contrast == .increased ? "↑" : "—")")
+                    Text("Ctr \(contrast == .increased ? "high" : "—")")
                 }
                 .font(.footnote)
                 .padding(8)

--- a/Tenney/Heji2FontRegistry.swift
+++ b/Tenney/Heji2FontRegistry.swift
@@ -1,0 +1,93 @@
+//
+//  Heji2FontRegistry.swift
+//  Tenney
+//
+
+import Foundation
+import CoreText
+import SwiftUI
+#if canImport(AppKit)
+import AppKit
+#endif
+#if canImport(UIKit)
+import UIKit
+#endif
+
+enum Heji2FontRegistry {
+    private static var didRegister = false
+
+    static var hejiTextFontName: String {
+        Heji2Mapping.shared.textFontName ?? "HEJI2Text"
+    }
+
+    static var hejiMusicFontName: String {
+        Heji2Mapping.shared.musicFontName ?? "HEJI2Music"
+    }
+
+    static func registerIfNeeded() {
+        guard !didRegister else { return }
+        didRegister = true
+        register(fontName: "HEJI2Text", ext: "otf")
+        register(fontName: "HEJI2Music", ext: "otf")
+        register(fontName: "HEJI2", ext: "otf")
+    }
+
+    static func preferredPointSize(for textStyle: Font.TextStyle) -> CGFloat {
+#if canImport(UIKit)
+        return UIFont.preferredFont(forTextStyle: textStyle.uiTextStyle).pointSize
+#elseif canImport(AppKit)
+        return NSFont.preferredFont(forTextStyle: textStyle.nsTextStyle).pointSize
+#else
+        return 16
+#endif
+    }
+
+    static func hejiTextFont(size: CGFloat, relativeTo textStyle: Font.TextStyle) -> Font {
+        Font.custom(hejiTextFontName, size: size, relativeTo: textStyle)
+    }
+
+    private static func register(fontName: String, ext: String) {
+        guard let url = Bundle.main.url(forResource: fontName, withExtension: ext) else { return }
+        CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+    }
+}
+
+#if canImport(UIKit)
+private extension Font.TextStyle {
+    var uiTextStyle: UIFont.TextStyle {
+        switch self {
+        case .largeTitle: return .largeTitle
+        case .title: return .title1
+        case .title2: return .title2
+        case .title3: return .title3
+        case .headline: return .headline
+        case .subheadline: return .subheadline
+        case .body: return .body
+        case .callout: return .callout
+        case .footnote: return .footnote
+        case .caption: return .caption1
+        case .caption2: return .caption2
+        @unknown default: return .body
+        }
+    }
+}
+#elseif canImport(AppKit)
+private extension Font.TextStyle {
+    var nsTextStyle: NSFont.TextStyle {
+        switch self {
+        case .largeTitle: return .largeTitle
+        case .title: return .title1
+        case .title2: return .title2
+        case .title3: return .title3
+        case .headline: return .headline
+        case .subheadline: return .subheadline
+        case .body: return .body
+        case .callout: return .callout
+        case .footnote: return .footnote
+        case .caption: return .caption1
+        case .caption2: return .caption2
+        @unknown default: return .body
+        }
+    }
+}
+#endif

--- a/Tenney/Heji2Mapping.swift
+++ b/Tenney/Heji2Mapping.swift
@@ -1,0 +1,117 @@
+//
+//  Heji2Mapping.swift
+//  Tenney
+//
+
+import Foundation
+
+struct Heji2Glyph: Hashable, Decodable {
+    let glyph: String
+    let staffOffset: Heji2Offset?
+    let textOffset: Heji2Offset?
+    let advance: Double?
+    let staffAdvance: Double?
+    let textAdvance: Double?
+
+    var string: String { glyph }
+}
+
+struct Heji2Offset: Hashable, Decodable {
+    let x: Double
+    let y: Double
+}
+
+final class Heji2Mapping {
+    static let shared = Heji2Mapping()
+
+    let textFontName: String?
+    let musicFontName: String?
+
+    private let diatonicAccidentals: [Int: [Heji2Glyph]]
+    private let primeComponents: [Int: Heji2DirectionalGlyphs]
+
+    private init() {
+        let bundles = [Bundle.main, Bundle(for: Heji2Mapping.self)]
+        let url = bundles.compactMap { $0.url(forResource: "heji2_mapping", withExtension: "json") }.first
+        guard let resourceUrl = url,
+              let data = try? Data(contentsOf: resourceUrl),
+              let decoded = try? JSONDecoder().decode(Heji2MappingPayload.self, from: data) else {
+            textFontName = nil
+            musicFontName = nil
+            diatonicAccidentals = [:]
+            primeComponents = [:]
+            return
+        }
+        textFontName = decoded.fonts?.text
+        musicFontName = decoded.fonts?.music
+        diatonicAccidentals = decoded.diatonicAccidentals.decodeIntKeyedGlyphs()
+        primeComponents = decoded.primeComponents.decodeIntKeyedComponents()
+    }
+
+    var supportedPrimes: Set<Int> {
+        Set(primeComponents.keys)
+    }
+
+    func glyphsForDiatonicAccidental(_ n: Int) -> [Heji2Glyph] {
+        guard n != 0 else { return [] }
+        if let direct = diatonicAccidentals[n] {
+            return direct
+        }
+        if n > 0, let unit = diatonicAccidentals[1] {
+            return Array(repeating: unit, count: n).flatMap { $0 }
+        }
+        if n < 0, let unit = diatonicAccidentals[-1] {
+            return Array(repeating: unit, count: abs(n)).flatMap { $0 }
+        }
+        return []
+    }
+
+    func glyphsForPrimeComponents(_ components: [HejiMicrotonalComponent]) -> [Heji2Glyph] {
+        var out: [Heji2Glyph] = []
+        for component in components {
+            guard let glyphs = primeComponents[component.prime] else { continue }
+            out.append(contentsOf: component.up ? glyphs.up : glyphs.down)
+        }
+        return out
+    }
+}
+
+private struct Heji2MappingPayload: Decodable {
+    let fonts: Heji2FontNames?
+    let diatonicAccidentals: [String: [Heji2Glyph]]
+    let primeComponents: [String: Heji2DirectionalGlyphs]
+}
+
+private struct Heji2FontNames: Decodable {
+    let text: String?
+    let music: String?
+}
+
+struct Heji2DirectionalGlyphs: Hashable, Decodable {
+    let up: [Heji2Glyph]
+    let down: [Heji2Glyph]
+}
+
+private extension Dictionary where Key == String, Value == [Heji2Glyph] {
+    func decodeIntKeyedGlyphs() -> [Int: [Heji2Glyph]] {
+        var out: [Int: [Heji2Glyph]] = [:]
+        for (key, value) in self {
+            if let intKey = Int(key) {
+                out[intKey] = value
+            }
+        }
+        return out
+    }
+}
+
+private extension Dictionary where Key == String, Value == Heji2DirectionalGlyphs {
+    func decodeIntKeyedComponents() -> [Int: Heji2DirectionalGlyphs] {
+        var out: [Int: Heji2DirectionalGlyphs] = [:]
+        for (key, value) in self {
+            if let intKey = Int(key) {
+                out[intKey] = value
+            }
+        }
+        return out
+    }
+}

--- a/Tenney/HejiGlyphs.swift
+++ b/Tenney/HejiGlyphs.swift
@@ -11,28 +11,6 @@ enum HejiGlyphs {
     static let fClef = "\u{E062}"
     static let noteheadBlack = "\u{E0A4}"
 
-    static func standardAccidental(for count: Int) -> String {
-        if count == 0 { return "" }
-        if count > 0 {
-            return String(repeating: "\u{E262}", count: count)
-        } else {
-            return String(repeating: "\u{E260}", count: abs(count))
-        }
-    }
-
-    static func microtonalGlyph(for component: HejiMicrotonalComponent) -> String {
-        switch component {
-        case .syntonic(let up):
-            return up ? "\u{E2C7}" : "\u{E2C2}"
-        case .septimal(let up):
-            return up ? "\u{E2DF}" : "\u{E2DE}"
-        case .undecimal(let up):
-            return up ? "\u{E2E3}" : "\u{E2E2}"
-        case .tridecimal(let up):
-            return up ? "\u{E2E7}" : "\u{E2E6}"
-        }
-    }
-
     static func glyphAvailable(_ glyph: String, fontName: String) -> Bool {
         guard let scalar = glyph.unicodeScalars.first else { return false }
         let font = CTFontCreateWithName(fontName as CFString, 16, nil)
@@ -41,4 +19,3 @@ enum HejiGlyphs {
         return CTFontGetGlyphsForCharacters(font, &character, &glyphs, 1)
     }
 }
-

--- a/Tenney/HejiPitchLabel.swift
+++ b/Tenney/HejiPitchLabel.swift
@@ -57,9 +57,14 @@ struct HejiPitchLabel: View {
             }
 
             if mode == .text || mode == .combined {
-                let label = HejiNotation.textLabelString(spelling, showCents: showCentsWhenApproximate)
-                Text(verbatim: label)
-                    .font(.headline.monospaced())
+                let label = HejiNotation.textLabel(
+                    spelling,
+                    showCents: showCentsWhenApproximate,
+                    textStyle: .headline,
+                    weight: .semibold,
+                    design: .monospaced
+                )
+                Text(label)
             }
 
             if !unsupported.isEmpty {

--- a/Tenney/HejiRatioDisplay.swift
+++ b/Tenney/HejiRatioDisplay.swift
@@ -18,7 +18,7 @@ func spellHejiRatioDisplay(
     allowApproximation: Bool,
     showCents: Bool = false,
     applyAccidentalPreference: Bool
-) -> String {
+) -> AttributedString {
     let preference = applyAccidentalPreference ? accidentalPreference : .auto
     let context = HejiContext(
         concertA4Hz: concertA4Hz,
@@ -31,5 +31,12 @@ func spellHejiRatioDisplay(
         scaleDegreeHint: ratio,
         tonicE3: tonic.e3
     )
-    return HejiNotation.textLabelString(for: ratio, context: context, showCents: showCents)
+    return HejiNotation.textLabel(
+        for: ratio,
+        context: context,
+        showCents: showCents,
+        textStyle: .footnote,
+        weight: .semibold,
+        design: .default
+    )
 }

--- a/Tenney/HejiRatioSpeller.swift
+++ b/Tenney/HejiRatioSpeller.swift
@@ -25,7 +25,7 @@ struct HejiRatioSpelling: Equatable {
     var isApproximate: Bool
 
     var labelText: String {
-        accidentalText + helmholtzText
+        helmholtzText + accidentalText
     }
 }
 
@@ -160,7 +160,7 @@ func spellRatio(p: Int, q: Int, context: PitchContext) -> HejiRatioSpelling {
     #endif
 
     let accidentalText = renderAccidentalText(accidentalCount)
-    let unsupported = unsupportedPrimes(p: rp, q: rq)
+    let unsupported = unsupportedPrimes(p: rp, q: rq, maxPrime: context.maxPrime)
     let helmholtz = helmholtzLabel(letter: letter, octave: scientificOctave)
 
     return HejiRatioSpelling(
@@ -241,11 +241,13 @@ private func helmholtzLabel(letter: String, octave: Int) -> String {
     return "\(upper)\(commas)"
 }
 
-private func unsupportedPrimes(p: Int, q: Int) -> [Int] {
+private func unsupportedPrimes(p: Int, q: Int, maxPrime: Int) -> [Int] {
     let remainingP = stripFactors(stripFactors(abs(p), prime: 2), prime: 3)
     let remainingQ = stripFactors(stripFactors(abs(q), prime: 2), prime: 3)
     let primes = Set(factorPrimes(remainingP) + factorPrimes(remainingQ))
-    return primes.filter { $0 >= 5 }.sorted()
+    let supported = Heji2Mapping.shared.supportedPrimes.filter { $0 <= maxPrime }
+    let allowed = Set([2, 3]).union(supported)
+    return primes.filter { !allowed.contains($0) }.sorted()
 }
 
 private func stripFactors(_ value: Int, prime: Int) -> Int {

--- a/Tenney/HejiStaffSnippetView.swift
+++ b/Tenney/HejiStaffSnippetView.swift
@@ -86,10 +86,6 @@ struct HejiStaffSnippetView: View {
 
             drawLedgerLines(step: layout.staffStepFromMiddle, metrics: m, y: y, topY: topY, bottomY: bottomLineY, ctx: &ctx)
 
-            if let approx = layout.approxMarkerGlyph {
-                let approxText = Text(approx).font(.system(size: m.accSize * 0.8, weight: .regular))
-                ctx.draw(approxText, at: CGPoint(x: m.width - 8, y: topY - snap(2 / displayScale)), anchor: .trailing)
-            }
         }
         .frame(width: m.width, height: m.height)
 
@@ -114,4 +110,3 @@ struct HejiStaffSnippetView: View {
         return (value * scale).rounded(.toNearestOrEven) / scale
     }
 }
-

--- a/Tenney/Info.plist
+++ b/Tenney/Info.plist
@@ -12,6 +12,8 @@
 	<array>
 		<string>Resources/Fonts/Bravura/Bravura.otf</string>
 		<string>Resources/Fonts/Bravura/BravuraText.otf</string>
+		<string>Resources/Fonts/HEJI2/HEJI2Text.otf</string>
+		<string>Resources/Fonts/HEJI2/HEJI2Music.otf</string>
 	</array>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>

--- a/Tenney/LearnTenneyReferenceSeries.swift
+++ b/Tenney/LearnTenneyReferenceSeries.swift
@@ -439,10 +439,8 @@ private struct TonicDegreeIntegrityReferenceView: View {
             ReferenceSection(title: "Worked example") {
                 LearnGlassCard {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("Root Hz = 415 · Tonic = G♯ · Ratio = 15/8")
-                            .font(.subheadline.weight(.semibold))
-                        Text("15/8 is a **major 7th** above the tonic. The 7th degree above G♯ must be the letter **F**, so the correct label is **F𝄪**, not “G.”")
-                            .font(.body)
+                        Text(workedExampleHeader())
+                        Text(workedExampleBody())
                     }
                 }
             }
@@ -731,4 +729,38 @@ private struct DiagramArrow: View {
             .foregroundStyle(.secondary)
             .padding(.top, 18)
     }
+}
+
+private func workedExampleHeader() -> AttributedString {
+    let size = Heji2FontRegistry.preferredPointSize(for: .subheadline)
+    var prefix = AttributedString("Root Hz = 415 · Tonic = G")
+    prefix.font = .system(size: size, weight: .semibold, design: .default)
+    let sharpGlyph = Heji2Mapping.shared.glyphsForDiatonicAccidental(1).map(\.string).joined()
+    var sharp = AttributedString(sharpGlyph)
+    sharp.font = Heji2FontRegistry.hejiTextFont(size: size, relativeTo: .subheadline)
+    var suffix = AttributedString(" · Ratio = 15/8")
+    suffix.font = .system(size: size, weight: .semibold, design: .default)
+    return prefix + sharp + suffix
+}
+
+private func workedExampleBody() -> AttributedString {
+    let size = Heji2FontRegistry.preferredPointSize(for: .body)
+    var text = AttributedString("15/8 is a major 7th above the tonic. The 7th degree above G")
+    text.font = .system(size: size, weight: .regular, design: .default)
+
+    let sharpGlyph = Heji2Mapping.shared.glyphsForDiatonicAccidental(1).map(\.string).joined()
+    var sharp = AttributedString(sharpGlyph)
+    sharp.font = Heji2FontRegistry.hejiTextFont(size: size, relativeTo: .body)
+
+    var mid = AttributedString(" must be the letter F, so the correct label is F")
+    mid.font = .system(size: size, weight: .regular, design: .default)
+
+    let doubleSharpGlyph = Heji2Mapping.shared.glyphsForDiatonicAccidental(2).map(\.string).joined()
+    var doubleSharp = AttributedString(doubleSharpGlyph)
+    doubleSharp.font = Heji2FontRegistry.hejiTextFont(size: size, relativeTo: .body)
+
+    var tail = AttributedString(", not “G.”")
+    tail.font = .system(size: size, weight: .regular, design: .default)
+
+    return text + sharp + mid + doubleSharp + tail
 }

--- a/Tenney/NotationFormatter.swift
+++ b/Tenney/NotationFormatter.swift
@@ -29,21 +29,21 @@ public enum NotationFormatter {
     // MIDI 69 = A4
     private static let a4MIDINote: Double = 69.0
 
-    // Chromatic spelling (letter + accidental). Use ♯ to match typical iOS typography.
-    private static let chromatic: [SpelledETNote] = [
-        ("C", "", 0), ("C", "♯", 0), ("D", "", 0), ("D", "♯", 0),
-        ("E", "", 0), ("F", "", 0), ("F", "♯", 0), ("G", "", 0),
-        ("G", "♯", 0), ("A", "", 0), ("A", "♯", 0), ("B", "", 0)
+    // Chromatic spelling (letter + accidental count).
+    private static let chromatic: [(letter: String, accidentalCount: Int)] = [
+        ("C", 0), ("C", 1), ("D", 0), ("D", 1),
+        ("E", 0), ("F", 0), ("F", 1), ("G", 0),
+        ("G", 1), ("A", 0), ("A", 1), ("B", 0)
     ]
-    private static let chromaticSharps: [SpelledETNote] = [
-        ("C", "", 0), ("C", "♯", 0), ("D", "", 0), ("D", "♯", 0),
-        ("E", "", 0), ("F", "", 0), ("F", "♯", 0), ("G", "", 0),
-        ("G", "♯", 0), ("A", "", 0), ("A", "♯", 0), ("B", "", 0)
+    private static let chromaticSharps: [(letter: String, accidentalCount: Int)] = [
+        ("C", 0), ("C", 1), ("D", 0), ("D", 1),
+        ("E", 0), ("F", 0), ("F", 1), ("G", 0),
+        ("G", 1), ("A", 0), ("A", 1), ("B", 0)
     ]
-    private static let chromaticFlats: [SpelledETNote] = [
-        ("C", "", 0), ("D", "♭", 0), ("D", "", 0), ("E", "♭", 0),
-        ("E", "", 0), ("F", "", 0), ("G", "♭", 0), ("G", "", 0),
-        ("A", "♭", 0), ("A", "", 0), ("B", "♭", 0), ("B", "", 0)
+    private static let chromaticFlats: [(letter: String, accidentalCount: Int)] = [
+        ("C", 0), ("D", -1), ("D", 0), ("E", -1),
+        ("E", 0), ("F", 0), ("G", -1), ("G", 0),
+        ("A", -1), ("A", 0), ("B", -1), ("B", 0)
     ]
 
     // MARK: - Public API
@@ -68,7 +68,7 @@ public enum NotationFormatter {
         let idx = mod12(midi)
         let octave = midi / 12 - 1
         let base = chromatic[idx]
-        return (base.letter, base.accidental, octave)
+        return (base.letter, accidentalGlyph(base.accidentalCount), octave)
     }
 
     /// Cent deviation from the nearest equal-tempered semitone (relative to A4 = a4Hz).
@@ -93,7 +93,7 @@ public enum NotationFormatter {
         let octave = midi / 12 - 1
         let spelling = spelledChromatic(for: idx, preference: preference)
         let helmholtz = helmholtzOctaveMarks(scientificOctave: octave, letter: spelling.letter)
-        return "\(helmholtz.caseAdjustedLetter)\(spelling.accidental)\(helmholtz.marks)"
+        return "\(helmholtz.caseAdjustedLetter)\(helmholtz.marks)\(spelling.accidental)"
     }
 
     /// HEJI-ish text label for ratio tiles / info cards.
@@ -142,10 +142,10 @@ public enum NotationFormatter {
         switch preference {
         case .preferFlats:
             let note = chromaticFlats[idx]
-            return (note.letter, note.accidental)
+            return (note.letter, accidentalGlyph(note.accidentalCount))
         case .preferSharps, .auto:
             let note = chromaticSharps[idx]
-            return (note.letter, note.accidental)
+            return (note.letter, accidentalGlyph(note.accidentalCount))
         }
     }
 

--- a/Tenney/Resources/heji2_mapping.json
+++ b/Tenney/Resources/heji2_mapping.json
@@ -1,0 +1,32 @@
+{
+  "fonts": {
+    "text": "HEJI2Text",
+    "music": "HEJI2Music"
+  },
+  "diatonicAccidentals": {
+    "1": [
+      { "glyph": "\uE262" }
+    ],
+    "-1": [
+      { "glyph": "\uE260" }
+    ]
+  },
+  "primeComponents": {
+    "5": {
+      "up": [{ "glyph": "\uE2C7" }],
+      "down": [{ "glyph": "\uE2C2" }]
+    },
+    "7": {
+      "up": [{ "glyph": "\uE2DF" }],
+      "down": [{ "glyph": "\uE2DE" }]
+    },
+    "11": {
+      "up": [{ "glyph": "\uE2E3" }],
+      "down": [{ "glyph": "\uE2E2" }]
+    },
+    "13": {
+      "up": [{ "glyph": "\uE2E7" }],
+      "down": [{ "glyph": "\uE2E6" }]
+    }
+  }
+}

--- a/Tenney/ScaleLibrarySheet.swift
+++ b/Tenney/ScaleLibrarySheet.swift
@@ -1140,7 +1140,7 @@ struct ScaleActionsSheet: View {
             .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
     }
 
-    private var headerSummary: String {
+    private var headerSummary: AttributedString {
         let pref = AccidentalPreference(rawValue: accidentalPreferenceRaw) ?? .auto
         let mode = TonicNameMode(rawValue: tonicNameModeRaw) ?? .auto
         let resolvedTonicE3 = TonicSpelling.resolvedTonicE3(
@@ -1163,9 +1163,20 @@ struct ScaleActionsSheet: View {
             tonicE3: resolvedTonicE3
         )
         let spelling = HejiNotation.spelling(forRatio: ratioRef, context: context)
-        let rootLabel = String(HejiNotation.textLabel(spelling, showCents: false).characters)
+        let rootLabel = HejiNotation.textLabel(
+            spelling,
+            showCents: false,
+            textStyle: .callout,
+            weight: .regular,
+            design: .default
+        )
         let hzInt = Int(round(currentScale.referenceHz))
-        return "\(currentScale.size) notes · \(currentScale.detectedLimit)-limit · Root: \(rootLabel) (\(hzInt) Hz)"
+        let baseSize = Heji2FontRegistry.preferredPointSize(for: .callout)
+        var prefix = AttributedString("\(currentScale.size) notes · \(currentScale.detectedLimit)-limit · Root: ")
+        prefix.font = .system(size: baseSize, weight: .regular, design: .default)
+        var suffix = AttributedString(" (\(hzInt) Hz)")
+        suffix.font = .system(size: baseSize, weight: .regular, design: .default)
+        return prefix + rootLabel + suffix
     }
 
     private var referenceSummary: String {
@@ -2278,7 +2289,7 @@ private struct OverviewPage: View {
     @FocusState private var titleFocused: Bool
 
     let title: String
-    let headerSummary: String
+    let headerSummary: AttributedString
     let referenceSummary: String
     let tags: [TagRef]
     let onOpen: () -> Void
@@ -2353,7 +2364,6 @@ private struct OverviewPage: View {
                     }
 
                     Text(headerSummary)
-                        .font(.callout)
                         .foregroundStyle(.secondary)
                         .monospacedDigit()
                     Text(referenceSummary)
@@ -2948,7 +2958,13 @@ private struct DegreeRow: View {
             tonicE3: resolvedTonicE3
         )
         let spelling = HejiNotation.spelling(forRatio: ratioRef, context: context)
-        let hejiLabel = String(HejiNotation.textLabel(spelling, showCents: false).characters)
+        let hejiLabel = HejiNotation.textLabel(
+            spelling,
+            showCents: false,
+            textStyle: .caption,
+            weight: .regular,
+            design: .default
+        )
 
         HStack(alignment: .center, spacing: 12) {
             VStack(alignment: .leading, spacing: 4) {
@@ -2963,8 +2979,7 @@ private struct DegreeRow: View {
                             .background(.thinMaterial, in: Capsule())
                     }
                 }
-                Text(verbatim: hejiLabel)
-                    .font(.caption)
+                Text(hejiLabel)
                     .foregroundStyle(.secondary)
             }
 

--- a/Tenney/TenneyApp.swift
+++ b/Tenney/TenneyApp.swift
@@ -55,6 +55,7 @@ struct TenneyApp: App {
 
     init() {
         BravuraFontRegistrar.registerIfNeeded()
+        Heji2FontRegistry.registerIfNeeded()
         seedLatticeSoundDefaultIfNeeded()
         configureAudioSessionFromDefaults()
         let crashInfo = SessionCrashMarker.shared.onLaunch()


### PR DESCRIPTION
### Motivation
- Replace ad-hoc arrows/12-EDO symbols and approximation markers with official HEJI2 glyphs as the single source of truth for accidentals and microtonal signs.
- Ensure accidentals are always rendered after the note letter/octave in all textual contexts and match staff glyphs visually (same HEJI2 glyphs, different fonts/layout).
- Make accidental rendering data-driven so future prime limits (e.g. up to 47-limit) can be supported just by extending the mapping, and keep font registration isolated.

### Description
- Added a HEJI2 font registry and mapping loader: `Tenney/Heji2FontRegistry.swift` (font registration + helpers) and `Tenney/Heji2Mapping.swift` plus bundled `Tenney/Resources/heji2_mapping.json` (tiny official mapping sample). Added `UIAppFonts` entries to `Tenney/Info.plist` for `HEJI2Text.otf` and `HEJI2Music.otf` (font binaries are not included here).  
- Data model & API: `Heji2Glyph`/payload decoding and runtime lookup helpers `glyphsForDiatonicAccidental(_:)` and `glyphsForPrimeComponents(_:)` (cached singleton `Heji2Mapping.shared`).  
- Text labels: replaced arrow/♯/♭/≈ string rendering with an AttributedString builder `HejiNotation.textLabel(...)` that appends HEJI2 text-font glyph runs after the Helmholtz letter+octave; removed the visible `≈` approx marker from text output. Tonic display exposes `attributedDisplayText(...)` so tonic and labels consistently use HEJI2 accidentals.  
- Staff rendering: added `HejiFont.heji2Text`/`.heji2Music` and changed `HejiNotation.staffAccidentalGlyphs(_:)` + `GlyphRun` usage to emit HEJI2 music-font glyphs (from the mapping) positioned with optional per-glyph offsets/advance hints; `HejiStaffSnippetView` now draws glyph runs using the registered HEJI2 music font.  
- Lattice/info/tuner surfaces: updated callers (LatticeView, ContentView, HejiPitchLabel, HejiRatioDisplay, ScaleLibrarySheet, etc.) to use the new AttributedString APIs and HEJI2 rendering so text and staff agree and accidentals are always after the note. Replaced inline Bravura accidental usages with HEJI2 where appropriate for microtonal glyphs.  
- Microtonal model: refactored `HejiMicrotonalComponent` to carry `prime` + `up` flags so mapping lookup is prime-driven and easily extendable. Accidentals are now filtered by what the mapping supports for the configured `maxPrime`.  
- NotationFormatter: updated `hejiAccidentalGlyph(forCents:)` to return HEJI2 glyphs via the mapping rather than arrow characters, and to pick the HEJI2 glyph for the nearest comma/prime.  
- Tests & copy: updated/added unit tests (`TenneyTests/HejiRatioDisplayTests.swift`) to assert that accidentals appear after the note+octave, that forbidden symbols (arrow chars, 12-EDO ♯/♭/♮, and `≈`) do not appear in exported text labels, and that supported primes include the HEJI defaults used by the mapping. Also adjusted tutorial/learning copy to render HEJI2 accidentals in-line.  
- Minor: removed visible approx markers from staff snippets and avoided inventing approximation symbols in UI; preserved Bravura noteheads/clefs while sourcing accidentals from HEJI2 music font.

Project settings / maintainer notes: add the official HEJI2 font files to the app target at `Resources/Fonts/HEJI2/HEJI2Text.otf` and `.../HEJI2Music.otf` and include them in Copy Bundle Resources (the PR only adds Info.plist entries and registration code; binaries are intentionally not added).

### Testing
- Tests added/updated: `TenneyTests/HejiRatioDisplayTests.swift` (asserts accidental ordering after note, forbids arrow/♯/♭/♮/≈ characters in textual outputs, and checks supported-prime behavior).  
- Integration smoke: font registration is invoked at app init (`TenneyApp.init` now calls `Heji2FontRegistry.registerIfNeeded()`), and mapping is cached on first access (`Heji2Mapping.shared`).  
- Automated test execution: unit tests were updated/added but were not executed in this change set in this environment; CI should run the test suite to validate compilation and behavior end-to-end.  
- Recommendation: add official HEJI2 font binaries to the bundle and run the test suite (and the app) in CI/macOS/iOS simulators to validate glyph availability and staff/layout offsets; adjust mapping JSON offsets if fine-tuning of positioning is needed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697537fff040832791ab3d310e2ff33e)