### PR TITLE
Fix HEJI accidental ordering and 13-limit font rendering

### DIFF
--- a/Tenney/Heji2Mapping.swift
+++ b/Tenney/Heji2Mapping.swift
@@ -77,9 +77,16 @@ final class Heji2Mapping {
         var out: [Heji2Glyph] = []
         for component in components {
             guard let stepsMap = primeComponents[component.prime] else { continue }
-                        let resolved = stepsMap[component.steps] ?? stepsMap[1] ?? stepsMap.values.first
-                        guard let glyphs = resolved else { continue }
-                        out.append(contentsOf: component.up ? glyphs.up : glyphs.down)
+            let resolved = stepsMap[component.steps] ?? stepsMap[1] ?? stepsMap.values.first
+            guard let glyphs = resolved else { continue }
+            if component.steps > 1, let baseGlyphs = stepsMap[1] ?? resolved {
+                let chosen = component.up ? baseGlyphs.up : baseGlyphs.down
+                for _ in 0..<component.steps {
+                    out.append(contentsOf: chosen)
+                }
+            } else {
+                out.append(contentsOf: component.up ? glyphs.up : glyphs.down)
+            }
         }
         return out
     }


### PR DESCRIPTION
### Motivation
- Correct incorrect ordering where arrow/comma modifiers were being attached before or to a placeholder natural, causing modifiers to bind to the wrong diatonic glyph for many 5‑limit cases.
- Ensure 13‑limit (tridecimal) microtonal glyphs are emitted in the HEJI/SMuFL font run so PUA glyphs render instead of falling back to system fonts or tofu.
- Support multi‑step microtonal components (e.g. double arrows) by repeating the appropriate glyphs rather than relying on mapped stepped entries alone.

### Description
- Changed HEJI text label construction to register HEJI fonts at label time by calling `Heji2FontRegistry.registerIfNeeded()` and split the label into a base (note letter/octave, system font) and accidental run (HEJI text font) in `HejiNotation.textLabel` so microtonal accidentals render in the SMuFL font run.
- Reordered accidental building so the diatonic/base accidental glyphs are emitted first and microtonal modifiers appended after in `HejiNotation.accidentalGlyphString` and `HejiNotation.staffAccidentalGlyphs`, and only insert a natural glyph when the diatonic accidental is actually natural (i.e. `diatonicAccidental == 0`) and microtonal modifiers exist.
- Updated prime component expansion in `Heji2Mapping.glyphsForPrimeComponents` to repeat step‑1 glyphs when `steps > 1` so multi‑step modifiers (double arrows/flags) are produced by repeating the single‑step glyphs rather than requiring bespoke entries.
- Added unit tests in `TenneyTests/HejiRatioDisplayTests.swift` to assert scalar ordering for representative 5‑limit cases and to verify 13‑limit accidentals use the HEJI text font run.

### Testing
- Verified HEJI font files contain required Private Use Area codepoints using `fontTools` via a local Python check, confirming both `HEJI2Text.otf` and `HEJI2.otf` include the expected glyph codepoints (check succeeded). 
- Added unit tests (`fiveLimitAccidentalsRenderInBaseThenModifierOrder` and `tridecimalAccidentalsUseHejiTextFontRun`) to `HejiRatioDisplayTests.swift`; these tests are present in the test target but were not executed in this environment because `xcodebuild` is not available here. 
- All code changes compiled and committed locally; unit test execution should be run in a macOS Xcode CI or local dev environment to confirm the test suite passes end‑to‑end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69755e618af8832782357ca7d13a4809)