### PR TITLE
Fix HEJI accidental ordering and stepped-prime glyph selection; add regression tests

### DIFF
--- a/Tenney/Heji2Mapping.swift
+++ b/Tenney/Heji2Mapping.swift
@@ -77,15 +77,19 @@ final class Heji2Mapping {
         var out: [Heji2Glyph] = []
         for component in components {
             guard let stepsMap = primeComponents[component.prime] else { continue }
-            let resolved = stepsMap[component.steps] ?? stepsMap[1] ?? stepsMap.values.first
-            guard let glyphs = resolved else { continue }
-            if component.steps > 1, let baseGlyphs = stepsMap[1] ?? resolved {
-                let chosen = component.up ? baseGlyphs.up : baseGlyphs.down
+            if let exact = stepsMap[component.steps] {
+                let chosen = component.up ? exact.up : exact.down
+                out.append(contentsOf: chosen)
+                continue
+            }
+            guard let baseGlyphs = stepsMap[1] ?? stepsMap.values.first else { continue }
+            let chosen = component.up ? baseGlyphs.up : baseGlyphs.down
+            if component.steps > 1 {
                 for _ in 0..<component.steps {
                     out.append(contentsOf: chosen)
                 }
             } else {
-                out.append(contentsOf: component.up ? glyphs.up : glyphs.down)
+                out.append(contentsOf: chosen)
             }
         }
         return out


### PR DESCRIPTION
### Motivation
- Fix two rendering bugs: (1) 5-limit accidentals showing an inserted natural glyph and microtonal modifiers attaching to that natural instead of the proper sharp/flat, and (2) missing 13-limit glyphs due to stepped-mapping fallback behavior.
- Ensure deterministic ordering so base diatonic accidental is always emitted before microtonal modifiers and dictionary iteration order cannot introduce instability.
- Add targeted DEBUG logging to confirm actual spelling details for problematic ratios during render debugging.
- The previous behavior could look like “no change” because a forced ♮ fallback was prepended whenever microtonal components existed (masking the intended base accidental), and the old stepped fallback repeated step-1 glyphs even when a legitimate exact `step>1` mapping existed (overriding intended glyphs including for prime 13).

### Description
- Removed the forced natural fallback in both `HejiNotation.staffAccidentalGlyphs(_:)` and `HejiNotation.accidentalGlyphString(for:)` so we no longer invent a base natural when `diatonicAccidental == 0` and microtonal components exist.
- Added `logHejiRenderingIfNeeded(_:)` (DEBUG-only) and call-site in `textLabel(for:context:...)` to print `baseLetter`, `diatonicAccidental`, and `microtonalComponents` tuples for the targeted ratios `32/25`, `5/4`, and `8/5`.
- Made microtonal component emission deterministic by iterating primes sorted in `HejiNotation.microtonalComponents(for:maxPrime:)`.
- Changed `Heji2Mapping.glyphsForPrimeComponents(_:)` to use an exact `steps` entry if present before falling back to repeating the `step=1` glyph; this preserves legitimate `step>1` glyph mappings (fixes 13-limit rendering).
- Added tight regression tests in `TenneyTests/HejiRatioDisplayTests.swift`: `fiveLimitAccidentalsAvoidForcedNaturals` to assert naturals are not forcibly prepended for `32/25` and `5/4` (and are present where expected for `8/5`), and `tridecimalGlyphsExistInHejiFont` to verify at least one glyph scalar for prime 13 maps into the registered HEJI font via `CTFontGetGlyphsForCharacters`.
- Adjusted the test helper `accidentalString(for:)` to match the production behavior (no forced natural fallback).

### Testing
- Added unit tests: `fiveLimitAccidentalsAvoidForcedNaturals` and `tridecimalGlyphsExistInHejiFont` in `TenneyTests/HejiRatioDisplayTests.swift` which will fail on the prior implementation and pass with these fixes.
- Attempted to run `xcodebuild -scheme TenneyTests -destination 'platform=macOS' test` in the current environment but `xcodebuild` is not available here, so automated test execution could not be completed in this environment; the tests are included and expected to run in CI or a macOS dev environment.
- Performed local code edits and committed the change (`Fix HEJI accidental ordering and 13-limit glyph checks`); please run the test suite in CI or locally (macOS) to validate all tests pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975624cb99483279fe8cf8ab5134314)