### PR TITLE
Fix HEJI2 prime-5 variant rendering and add step-3 glyph

### DIFF
--- a/Tenney/Heji2Mapping.swift
+++ b/Tenney/Heji2Mapping.swift
@@ -90,7 +90,11 @@ final class Heji2Mapping {
             guard let stepsMap = primeComponents[component.prime] else { continue }
             if let exact = stepsMap[component.steps] {
                 let chosen = component.up ? exact.up : exact.down
-                out.append(contentsOf: chosen)
+                out.append(contentsOf: applyPrime5VariantIfNeeded(
+                    chosen,
+                    prime: component.prime,
+                    diatonicAccidental: diatonicAccidental
+                ))
                 continue
             }
             guard let baseGlyphs = stepsMap[1] ?? stepsMap.values.first else { continue }
@@ -123,7 +127,6 @@ final class Heji2Mapping {
     ) -> [Heji2Glyph] {
         guard prime == 5 else { return glyphs }
         guard abs(diatonicAccidental) == 1 else { return glyphs } // keep this tight/safe
-        let delta: UInt32 = diatonicAccidental < 0 ? 0xFFFF_FFFF : 1 // -1 or +1
 
         // Attempt to shift each glyph by ±1 codepoint (SMuFL flat/natural/sharp grouping).
         return glyphs.map { g in

--- a/Tenney/Resources/heji2_mapping.json
+++ b/Tenney/Resources/heji2_mapping.json
@@ -12,7 +12,8 @@
   "primeComponents": {
         "5": {
         "1": { "up": [{ "glyph": "\uE2C7" }], "down": [{ "glyph": "\uE2C2" }] },
-        "2": { "up": [{ "glyph": "\uE2D1" }], "down": [{ "glyph": "\uE2CC" }] }
+        "2": { "up": [{ "glyph": "\uE2D1" }], "down": [{ "glyph": "\uE2CC" }] },
+        "3": { "up": [{ "glyph": "\uE2DB" }], "down": [{ "glyph": "\uE2D6" }] }
       },
       "7": {
         "1": { "up": [{ "glyph": "\uE2DF" }], "down": [{ "glyph": "\uE2DE" }] },

--- a/TenneyTests/HejiPrime5RenderingTests.swift
+++ b/TenneyTests/HejiPrime5RenderingTests.swift
@@ -1,0 +1,44 @@
+//
+//  HejiPrime5RenderingTests.swift
+//  TenneyTests
+//
+
+import Testing
+@testable import Tenney
+
+struct HejiPrime5RenderingTests {
+
+    private let context = HejiContext(
+        concertA4Hz: 440,
+        noteNameA4Hz: 440,
+        rootHz: 440,
+        rootRatio: nil,
+        preferred: .auto,
+        maxPrime: 13,
+        allowApproximation: false,
+        scaleDegreeHint: nil,
+        tonicE3: nil
+    )
+
+    @Test func prime5DownOneUsesSharpVariant() async throws {
+        let ratio = RatioRef(p: 5, q: 3, octave: 0, monzo: [:])
+        let label = HejiNotation.textLabelString(for: ratio, context: context, showCents: false)
+        let sharpDownOne = "\u{E2C3}"
+        let naturalDownOne = "\u{E2C2}"
+        #expect(label.contains(sharpDownOne))
+        #expect(!label.contains(naturalDownOne))
+    }
+
+    @Test func prime5DownThreeUsesSingleSharpVariant() async throws {
+        let ratio = RatioRef(p: 125, q: 108, octave: 0, monzo: [:])
+        let label = HejiNotation.textLabelString(for: ratio, context: context, showCents: false)
+        let sharpDownThree = "\u{E2D7}"
+        let naturalDownThree = "\u{E2D6}"
+        #expect(label.contains(sharpDownThree))
+        #expect(!label.contains(naturalDownThree))
+        #expect(!label.contains("\u{E2C2}"))
+        #expect(!label.contains("\u{E2C3}"))
+        #expect(!label.contains("\u{E2CC}"))
+        #expect(!label.contains("\u{E2CD}"))
+    }
+}


### PR DESCRIPTION
### Motivation
- Fix a bug where prime-5 microtonal accidentals rendered as a natural-with-arrows even when the spelled diatonic pitch was sharp/flat, causing cases like `5/3` to show `F♮ + down-1` instead of `F# + down-1`.
- Ensure exponent cases like `5^3` decompose to a single three-arrow glyph rather than multiple smaller glyphs (e.g. `2+1`).

### Description
- Always apply `applyPrime5VariantIfNeeded(...)` to exact step matches inside `glyphsForPrimeComponents(...)` in `Tenney/Heji2Mapping.swift` so diatonic ±1 is absorbed into prime-5 glyph variants.
- Removed the unused `delta` local from `applyPrime5VariantIfNeeded(...)` to keep the change minimal and clean.
- Added a `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69758bf58f8c8327986e70e95c1b0925)