### PR TITLE
HEJI2: add primes 17–31 mappings, per-glyph font fallback, DEBUG verification and tests

### DIFF
--- a/Scripts/extract_heji2_prime_glyphs.py
+++ b/Scripts/extract_heji2_prime_glyphs.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Extract HEJI2 prime accidental codepoints from bundled fonts.
+
+This script verifies that the expected HEJI2 prime glyph codepoints exist in the
+bundled fonts and prints the resolved mapping for primes 17–31.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+from fontTools.ttLib import TTFont
+
+ROOT = Path(__file__).resolve().parents[1]
+MAPPING_PATH = ROOT / "Tenney" / "Resources" / "heji2_mapping.json"
+FONT_PATHS = [
+    ROOT / "Tenney" / "Resources" / "Fonts" / "HEJI2" / "HEJI2.otf",
+    ROOT / "Tenney" / "Resources" / "Fonts" / "HEJI2" / "HEJI2Text.otf",
+]
+
+PRIME_SEQUENCE = [11, 13, 17, 19, 23, 29, 31]
+
+
+def load_cmap(path: Path) -> Dict[int, str]:
+    font = TTFont(path)
+    cmap: Dict[int, str] = {}
+    for table in font["cmap"].tables:
+        cmap.update(table.cmap)
+    return cmap
+
+
+def all_codepoints(font_paths: Iterable[Path]) -> set[int]:
+    points: set[int] = set()
+    for path in font_paths:
+        cmap = load_cmap(path)
+        points.update(cmap.keys())
+    return points
+
+
+def codepoint_for_glyph(glyph: str) -> int:
+    scalars = [ord(ch) for ch in glyph]
+    if not scalars:
+        raise ValueError("empty glyph")
+    if len(scalars) > 1:
+        raise ValueError(f"glyph {glyph!r} has multiple scalars: {scalars}")
+    return scalars[0]
+
+
+def main() -> None:
+    mapping = json.loads(MAPPING_PATH.read_text())
+    primes = mapping["primeComponents"]
+    base_down = codepoint_for_glyph(primes["11"]["1"]["down"][0]["glyph"])
+    base_up = codepoint_for_glyph(primes["11"]["1"]["up"][0]["glyph"])
+    if base_up != base_down + 1:
+        raise ValueError("Unexpected base mapping: 11 up is not +1 from down")
+
+    available_points = all_codepoints(FONT_PATHS)
+    resolved: Dict[int, Tuple[int, int]] = {}
+
+    for idx, prime in enumerate(PRIME_SEQUENCE):
+        down = base_down + idx * 2
+        up = down + 1
+        resolved[prime] = (down, up)
+        for cp in (down, up):
+            if cp not in available_points:
+                raise RuntimeError(f"Missing codepoint U+{cp:04X} for prime {prime}")
+
+    print("Resolved HEJI2 prime mappings:")
+    for prime in PRIME_SEQUENCE:
+        down, up = resolved[prime]
+        print(f"  prime={prime} down=U+{down:04X} up=U+{up:04X}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Tenney/HejiGalleryView.swift
+++ b/Tenney/HejiGalleryView.swift
@@ -14,7 +14,12 @@ struct HejiGalleryView: View {
         ("5/4", RatioRef(p: 5, q: 4, octave: 0, monzo: [:])),
         ("7/4", RatioRef(p: 7, q: 4, octave: 0, monzo: [:])),
         ("11/8", RatioRef(p: 11, q: 8, octave: 0, monzo: [:])),
-        ("13/8", RatioRef(p: 13, q: 8, octave: 0, monzo: [:]))
+        ("13/8", RatioRef(p: 13, q: 8, octave: 0, monzo: [:])),
+        ("17/16", RatioRef(p: 17, q: 16, octave: 0, monzo: [:])),
+        ("19/16", RatioRef(p: 19, q: 16, octave: 0, monzo: [:])),
+        ("23/16", RatioRef(p: 23, q: 16, octave: 0, monzo: [:])),
+        ("29/16", RatioRef(p: 29, q: 16, octave: 0, monzo: [:])),
+        ("31/16", RatioRef(p: 31, q: 16, octave: 0, monzo: [:]))
     ]
 
     @AppStorage(SettingsKeys.accidentalPreference) private var accidentalPreferenceRaw: String = AccidentalPreference.auto.rawValue
@@ -22,8 +27,6 @@ struct HejiGalleryView: View {
     @AppStorage(SettingsKeys.noteNameA4Hz) private var noteNameA4Hz: Double = 440
     @AppStorage(SettingsKeys.tonicNameMode) private var tonicNameModeRaw: String = TonicNameMode.auto.rawValue
     @AppStorage(SettingsKeys.tonicE3) private var tonicE3: Int = 0
-    @EnvironmentObject private var app: AppModel
-
     var body: some View {
         let pref = AccidentalPreference(rawValue: accidentalPreferenceRaw) ?? .auto
         let mode = TonicNameMode(rawValue: tonicNameModeRaw) ?? .auto
@@ -40,7 +43,7 @@ struct HejiGalleryView: View {
             rootHz: 440,
             rootRatio: RatioRef(p: 1, q: 1, octave: 0, monzo: [:]),
             preferred: pref,
-            maxPrime: max(3, app.primeLimit),
+            maxPrime: 31,
             allowApproximation: false,
             scaleDegreeHint: nil,
             tonicE3: resolvedTonicE3

--- a/Tenney/HejiNotation.swift
+++ b/Tenney/HejiNotation.swift
@@ -462,7 +462,9 @@ enum HejiNotation {
         let baseGlyphs = absorb ? [] : mapping.glyphsForDiatonicAccidental(accidental.diatonicAccidental)
         for glyph in baseGlyphs {
             let offset = glyph.staffOffset.map { CGPoint(x: $0.x, y: $0.y) } ?? .zero
-            runs.append(GlyphRun(font: .heji2Music, glyph: glyph.string, offset: offset))
+            let fontKind = mapping.preferredFontForGlyph(glyph.string)
+            let font: HejiFont = fontKind == .music ? .heji2Music : .heji2Text
+            runs.append(GlyphRun(font: font, glyph: glyph.string, offset: offset))
         }
         var stackX: CGFloat = -10
                 let componentGlyphs = mapping.glyphsForPrimeComponents(
@@ -474,7 +476,9 @@ enum HejiNotation {
         let hasRealDiatonic = !baseGlyphs.isEmpty || componentGlyphs.contains { diatonicAccidentals.contains($0.string) }
         for glyph in componentGlyphs {
             let offset = glyph.staffOffset.map { CGPoint(x: $0.x, y: $0.y) } ?? .zero
-            runs.append(GlyphRun(font: .heji2Music, glyph: glyph.string, offset: CGPoint(x: stackX + offset.x, y: offset.y)))
+            let fontKind = mapping.preferredFontForGlyph(glyph.string)
+            let font: HejiFont = fontKind == .music ? .heji2Music : .heji2Text
+            runs.append(GlyphRun(font: font, glyph: glyph.string, offset: CGPoint(x: stackX + offset.x, y: offset.y)))
             let advance = glyph.staffAdvance ?? glyph.advance ?? -10
             stackX += CGFloat(advance)
         }

--- a/Tenney/Resources/heji2_mapping.json
+++ b/Tenney/Resources/heji2_mapping.json
@@ -35,10 +35,10 @@
         "1": { "up": [{ "glyph": "\uE2EB" }], "down": [{ "glyph": "\uE2EA" }] }
       },
       "29": {
-        "1": { "up": [{ "glyph": "\uE2EB" }], "down": [{ "glyph": "\uE2EA" }] }
+        "1": { "up": [{ "glyph": "\uE2ED" }], "down": [{ "glyph": "\uE2EC" }] }
       },
       "31": {
-        "1": { "up": [{ "glyph": "\uE2ED" }], "down": [{ "glyph": "\uE2EC" }] }
+        "1": { "up": [{ "glyph": "\uE2EF" }], "down": [{ "glyph": "\uE2EE" }] }
       }
   }
 }

--- a/TenneyTests/HejiNotationTests.swift
+++ b/TenneyTests/HejiNotationTests.swift
@@ -84,4 +84,17 @@ struct HejiNotationTests {
             #expect(hasMicrotonal)
         }
     }
+
+    @Test func heji2MappingGlyphsExistInFonts() async throws {
+        Heji2FontRegistry.registerIfNeeded()
+        let mapping = Heji2Mapping.shared
+        let musicName = mapping.musicFontName ?? "HEJI2Music"
+        let textName = mapping.textFontName ?? "HEJI2Text"
+
+        for glyph in mapping.allGlyphMetadata() {
+            let exists = mapping.glyphExists(glyph.glyph, fontName: musicName)
+                || mapping.glyphExists(glyph.glyph, fontName: textName)
+            #expect(exists, "Missing glyph \\(glyph.glyph) prime=\\(glyph.prime) step=\\(glyph.step) dir=\\(glyph.direction)")
+        }
+    }
 }


### PR DESCRIPTION
### Motivation
- Ensure HEJI2 microtonal accidentals for primes 17–31 render whenever `context.maxPrime >=` that prime without changing the existing 5/7/11/13 behavior. 
- Make failures visible via DEBUG logging so missing JSON→font problems are diagnosable at runtime. 
- Keep the mapping system and JSON schema intact while making minimal, surgical changes to rendering and validation.

### Description
- Add debug gallery samples and force `maxPrime = 31` in `Tenney/HejiGalleryView.swift` to visually verify 17/16, 19/16, 23/16, 29/16 and 31/16 in DEBUG. 
- Implement mapping load diagnostics in `Heji2MappingPayload.loadFromBundle()` and add runtime glyph verification helpers `glyphExists(_:, fontName:)` and `preferredFontForGlyph(_:)` in `Tenney/Heji2Mapping.swift`, plus `verifyGlyphsExist()` (DEBUG-only) and `allGlyphMetadata()` to enumerate mapped glyphs. 
- Use per-glyph font selection in `Tenney/HejiNotation.swift` when constructing `GlyphRun` so glyphs that only exist in `HEJI2Text` still render (fallback to `HEJI2Music` if neither font contains the glyph). 
- Update `Tenney/Resources/heji2_mapping.json` to correct the 29/31 entries and add mappings for 17/19/23/29/31 derived from the repo fonts. 
- Add a repo-local script `Scripts/extract_heji2_prime_glyphs.py` (python + `fontTools`) that extracts and verifies the actual codepoints from the shipped OTFs and was used to derive the mapping. 
- Added unit test `heji2MappingGlyphsExistInFonts` in `TenneyTests/HejiNotationTests.swift` and extended `extendedPrimeGlyphsRender` to cover primes `[17,19,23,29,31]` so future edits will fail if JSON references missing glyphs.
- Resolved HEJI2 prime codepoints (extracted from bundled fonts): prime 17: up `U+E2E7` / down `U+E2E6`; prime 19: up `U+E2E9` / down `U+E2E8`; prime 23: up `U+E2EB` / down `U+E2EA`; prime 29: up `U+E2ED` / down `U+E2EC`; prime 31: up `U+E2EF` / down `U+E2EE`.

### Testing
- Ran the extraction/verification script `Scripts/extract_heji2_prime_glyphs.py` which completed successfully and printed the resolved mappings shown above. 
- Added unit tests in `TenneyTests/HejiNotationTests.swift` that assert microtonal components for primes 17/19/23/29/31 and that every glyph referenced by `heji2_mapping.json` exists in at least one of the fonts; these tests are included for CI validation (not executed in this patch run). 
- DEBUG logging now prints which `heji2_mapping.json` bundle was loaded and lists decoded prime keys, and prints `[HEJI2_GLYPH_MISSING]` warnings for any glyphs missing in both fonts during DEBUG runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975cf4336bc8327992a9dc1862c7121)