### PR TITLE
Lattice: allow HEJI2 primes up to visible overlays in labels

### DIFF
--- a/TenneyTests/HejiNotationTests.swift
+++ b/TenneyTests/HejiNotationTests.swift
@@ -59,6 +59,15 @@ struct HejiNotationTests {
         #expect(tridecimal.accidental.microtonalComponents.contains(.tridecimal(up: false)))
     }
 
+    @Test func maxPrimeGatesHigherPrimeComponents() async throws {
+        let ratio = Ratio(17, 16)
+        let lowPrime = HejiNotation.spelling(forRatio: ratio, context: context)
+        #expect(!lowPrime.accidental.microtonalComponents.contains { $0.prime == 17 })
+
+        let highPrime = HejiNotation.spelling(forRatio: ratio, context: extendedContext)
+        #expect(highPrime.accidental.microtonalComponents.contains { $0.prime == 17 })
+    }
+
     @Test func extendedPrimeGlyphsRender() async throws {
         let ratios: [(prime: Int, ratio: RatioRef)] = [
             (17, RatioRef(p: 17, q: 16, octave: 0, monzo: [:])),


### PR DESCRIPTION
### Motivation

- Fix a bug where HEJI2 primes (13–31) render in `HejiGalleryView` but lattice overlay labels only showed ordinary ♯/♭ because `HejiContext.maxPrime` used in the lattice label path was too low.
- Make a surgical, localized change so lattice labels can emit higher-prime microtonal components when the lattice is actually displaying those primes without changing global `app.primeLimit` semantics.

### Description

- Add `effectiveMaxPrimeForLatticeLabels` computed from `store.visiblePrimes.max()` and `app.primeLimit` to decide the max prime the lattice should allow for labels.
- Thread an override into the label path by changing `overlayLabelText` to `overlayLabelText(num:den:prime:maxPrimeOverride:)`, computing `labelMaxPrime` in `drawOverlay`, and passing it through to label creation.
- Refactor HEJI context creation into `hejiContext(for:rootHz:maxPrime:)` and extend `hejiTextLabel(..., maxPrimeOverride:)` to accept the override without changing plane-node defaults.
- Add a `#if DEBUG` diagnostic log `[LATTICE_HEJI_MAXPRIME_MISMATCH]` inside the overlay label path when a ratio that should contain a given overlay prime lacks that microtonal component.

### Testing

- Add unit test `maxPrimeGatesHigherPrimeComponents` in `TenneyTests/HejiNotationTests.swift` that asserts a `Ratio(17,16)` omits prime 17 with `maxPrime: 13` and includes it with `maxPrime: 31`.
- No automated tests were executed during this rollout (tests were added but the test suite was not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697654ec3d3c8327b3b621e6550ffacd)