### PR TITLE
Normalize HEJI accidental rendering: prime-11 suppression, prime-5 absorption, and coalescing

### DIFF
--- a/TenneyTests/HejiAccidentalRenderingNormalizationTests.swift
+++ b/TenneyTests/HejiAccidentalRenderingNormalizationTests.swift
@@ -1,0 +1,54 @@
+//
+//  HejiAccidentalRenderingNormalizationTests.swift
+//  TenneyTests
+//
+
+import Testing
+@testable import Tenney
+
+struct HejiAccidentalRenderingNormalizationTests {
+
+    private let context = HejiContext(
+        concertA4Hz: 440,
+        noteNameA4Hz: 440,
+        rootHz: 440,
+        rootRatio: nil,
+        preferred: .auto,
+        maxPrime: 13,
+        allowApproximation: false,
+        scaleDegreeHint: nil,
+        tonicE3: nil
+    )
+
+    private let diatonicSet: Set<UInt32> = [
+        0xE260, 0xE261, 0xE262, 0xE263, 0xE264, 0xE265, 0xE266
+    ]
+
+    private func assertNoDiatonicAndHasMicrotonal(_ label: String) {
+        let scalars = label.unicodeScalars.map(\.value)
+        let hasDiatonic = scalars.contains { diatonicSet.contains($0) }
+        let hasMicrotonal = scalars.contains { (0xE000...0xF8FF).contains($0) && !diatonicSet.contains($0) }
+        #expect(!hasDiatonic, "Expected no diatonic accidental scalars in \\(label).")
+        #expect(hasMicrotonal, "Expected microtonal PUA scalar in \\(label).")
+    }
+
+    @Test func prime11SuppressesDiatonicAccidentals() async throws {
+        let ratios: [RatioRef] = [
+            RatioRef(p: 11, q: 8, octave: 0, monzo: [:]),
+            RatioRef(p: 16, q: 11, octave: 0, monzo: [:]),
+            RatioRef(p: 128, q: 121, octave: 0, monzo: [:]),
+            RatioRef(p: 1331, q: 1024, octave: 0, monzo: [:])
+        ]
+
+        for ratio in ratios {
+            let label = HejiNotation.textLabelString(for: ratio, context: context, showCents: false)
+            assertNoDiatonicAndHasMicrotonal(label)
+        }
+    }
+
+    @Test func prime5AbsorbsDiatonicAccidentals() async throws {
+        let ratio = RatioRef(p: 125, q: 64, octave: 0, monzo: [:])
+        let label = HejiNotation.textLabelString(for: ratio, context: context, showCents: false)
+        assertNoDiatonicAndHasMicrotonal(label)
+    }
+}


### PR DESCRIPTION
### Motivation
- Fix inconsistent accidental rendering where undecimal (prime-11) or prime-5 microtonal components produced incorrect diatonic stacking without changing spelling/math logic.
- Apply render-only normalization so staff glyph runs and text labels match exactly without touching pythagorean/prime derivation or note-name heuristics.

### Description
- Add `normalizedForRendering(_:)` in `Tenney/HejiNotation.swift` and use it from both `staffAccidentalGlyphs` and `accidentalGlyphString` to implement prime-11 suppression and prime-5 absorption at render time only.
- In `Tenney/Heji2Mapping.swift` coalesce microtonal components by `(prime, up)` and greedily decompose summed steps via `availableSteps(forPrime:)` to avoid redundant glyphs during rendering.
- Extend `applyPrime5VariantIfNeeded(...)` to accept diatonic accidental values in `-2...2`, shift prime-5 glyph codepoints by the diatonic offset (with safe single-scalar and glyph-existence checks), and return fallbacks if shifting would produce missing glyphs.
- Keep all changes surgical and render-layer-only: no changes to spelling, prime factoring, or other logic; added a focused test file `TenneyTests/HejiAccidentalRenderingNormalizationTests.swift` that asserts prime-11 suppression and prime-5 absorption in label output.

### Testing
- Added unit tests `TenneyTests/HejiAccidentalRenderingNormalizationTests.swift` covering prime-11 suppression for several ratios and a prime-5 absorption case, asserting absence of diatonic accidentals and presence of microtonal PUA scalars.
- Attempted to run `xcodebuild test -scheme Tenney -destination 'platform=macOS'` but the environment does not provide `xcodebuild`, so no automated tests were executed in this environment.
- The changes are intentionally small and localized to `HejiNotation.swift` and `Heji2Mapping.swift` to minimize regression risk and keep behavior locked by the added tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69766386ef688327b51dca4847258531)