### PR TITLE
HEJI: prime-17 near-tonic anchoring and prime-19 direction/enharmonic fixes

### DIFF
--- a/TenneyTests/HejiPrime17And19SpellingTests.swift
+++ b/TenneyTests/HejiPrime17And19SpellingTests.swift
@@ -1,0 +1,70 @@
+//
+//  HejiPrime17And19SpellingTests.swift
+//  TenneyTests
+//
+
+import Testing
+@testable import Tenney
+
+struct HejiPrime17And19SpellingTests {
+    private let context: HejiContext = {
+        let tonicA = TonicSpelling.from(letter: "A", accidental: 0).e3
+        return HejiContext(
+            concertA4Hz: 440,
+            noteNameA4Hz: 440,
+            rootHz: 440,
+            rootRatio: nil,
+            preferred: .auto,
+            maxPrime: 31,
+            allowApproximation: false,
+            scaleDegreeHint: nil,
+            tonicE3: tonicA
+        )
+    }()
+
+    @Test func prime17NearTonicAnchoring() async throws {
+        let first = HejiNotation.spelling(forRatio: Ratio(17, 16), context: context)
+        #expect(first.baseLetter == "A")
+        #expect(first.accidental.diatonicAccidental == 1)
+        #expect(first.accidental.microtonalComponents.contains { $0.prime == 17 && $0.steps == 1 && !$0.up })
+
+        let second = HejiNotation.spelling(forRatio: Ratio(289, 256), context: context)
+        #expect(second.baseLetter == "A")
+        #expect(second.accidental.diatonicAccidental == 2)
+        #expect(second.accidental.microtonalComponents.contains { $0.prime == 17 && $0.steps == 2 && !$0.up })
+
+        let third = HejiNotation.spelling(forRatio: Ratio(512, 289), context: context)
+        #expect(third.baseLetter == "A")
+        #expect(third.accidental.diatonicAccidental == -2)
+        #expect(third.accidental.microtonalComponents.contains { $0.prime == 17 && $0.steps == 2 && !$0.up })
+    }
+
+    @Test func prime19DirectionAndEnharmonicPreference() async throws {
+        let up = HejiNotation.spelling(forRatio: Ratio(19, 16), context: context)
+        #expect(up.baseLetter == "C")
+        #expect(up.accidental.diatonicAccidental == 0)
+        #expect(up.accidental.microtonalComponents.contains { $0.prime == 19 && $0.steps == 1 && $0.up })
+
+        let down = HejiNotation.spelling(forRatio: Ratio(32, 19), context: context)
+        #expect(down.baseLetter == "F")
+        #expect(down.accidental.diatonicAccidental == 1)
+        #expect(down.accidental.microtonalComponents.contains { $0.prime == 19 && $0.steps == 1 && !$0.up })
+
+        let downTwo = HejiNotation.spelling(forRatio: Ratio(512, 361), context: context)
+        #expect(downTwo.baseLetter == "D")
+        #expect(downTwo.accidental.diatonicAccidental == 1)
+        #expect(downTwo.accidental.microtonalComponents.contains { $0.prime == 19 && $0.steps == 2 && !$0.up })
+
+        let upTwo = HejiNotation.spelling(forRatio: Ratio(361, 256), context: context)
+        #expect(upTwo.baseLetter == "E")
+        #expect(upTwo.accidental.diatonicAccidental == -1)
+        #expect(upTwo.accidental.microtonalComponents.contains { $0.prime == 19 && $0.steps == 2 && $0.up })
+    }
+
+    @Test func prime11SpellingRemainsStable() async throws {
+        let undecimal = HejiNotation.spelling(forRatio: Ratio(11, 8), context: context)
+        #expect(undecimal.baseLetter == "F")
+        #expect(undecimal.accidental.diatonicAccidental == -2)
+        #expect(undecimal.accidental.microtonalComponents.contains { $0.prime == 11 })
+    }
+}


### PR DESCRIPTION
### Motivation
- Correct HEJI spelling issues for prime 17 and prime 19 at the spelling layer while keeping render-layer and glyph/mapping behavior unchanged.
- Ensure near-tonic prime-17 cases anchor to the tonic letter and express small offsets via diatonic accidentals, and make prime-19 direction consistent with numerator-up/denominator-down semantics and prefer appropriate enharmonic sides.

### Description
- Fix `hejiUpDirection(forPrime:exponent:)` by adding a `case 19` that returns `exp > 0` so prime-19 is numerator-up and denominator-down only for prime 19, leaving other primes unchanged.
- In `HejiNotation.spelling(forRatio:octave:context:)` add a tight, guarded prime-17 near-tonic override that: detects presence of prime 17 in microtonal components, computes `semitone = Int(round(12 * log2(ratioValue)))` as a trigger, and if `abs(semitone) <= 2` forces `baseLetter` to the tonic (`context.tonicE3`), clamps `diatonicAccidental` to `-2...2`, and rewrites any prime-17 microtonal components to `up=false` while preserving `steps`.
- Add a small post-pass for prime-19 that inspects the rendered prime-19 component direction and applies a local enharmonic rewrite via a private helper `rewriteEnharmonic(letter:accidental:preferSharps:)` which only handles the 7 letters and accidentals in `-2...2` and prefers flats when `up=true` and sharps when `up=false` (with collapse cases like `B#→C` and `Cb→B`).
- Keep all other microtonal and render-layer logic untouched; the changes only mutate `baseLetter` and `diatonicAccidental` and the `up` flag for prime-17 components in the near-tonic branch; added private helpers `roundedSemitoneOffset` and `rewriteEnharmonic` colocated in `Tenney/HejiNotation.swift`.
- Add `TenneyTests/HejiPrime17And19SpellingTests.swift` with a `HejiContext(maxPrime: 31)` anchored to tonic A and tests asserting the exact expected `baseLetter`, `diatonicAccidental`, and prime component `steps`/`up` for the provided ratios, plus a regression guard for an `11/8` case.

### Testing
- Added unit tests in `TenneyTests/HejiPrime17And19SpellingTests.swift` that cover the requested prime-17 near-tonic cases (`17/16`, `289/256`, `512/289`), prime-19 direction/enharmonic examples (`19/16`, `32/19`, `512/361`, `361/256`), and a prime-11 stability guard (`11/8`).
- Attempted to run the test suite with `xcodebuild test -scheme Tenney -destination 'platform=iOS Simulator,name=iPhone 15'`, but `xcodebuild` is not available in this environment so automated test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69766b80f2588327a358593bf6e4a6dd)