### PR TITLE
Fix HEJI2 glyph mappings for primes 29 and 31

### DIFF
--- a/Scripts/extract_heji2_prime_glyphs.py
+++ b/Scripts/extract_heji2_prime_glyphs.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import Dict, Iterable, Tuple
 
 from fontTools.ttLib import TTFont
-from PIL import Image, ImageDraw, ImageFont
 
 ROOT = Path(__file__).resolve().parents[1]
 MAPPING_PATH = ROOT / "Tenney" / "Resources" / "heji2_mapping.json"
@@ -21,12 +20,10 @@ FONT_PATHS = [
 ]
 
 PRIME_SEQUENCE = [11, 13, 17, 19, 23]
-PRIME_29_31_CANDIDATE_PAIRS = [
-    (0xE2EC, 0xE2ED),
-    (0xE2EE, 0xE2EF),
-    (0xE2F0, 0xE2F1),
-    (0xE2F2, 0xE2F3),
-]
+EXPECTED_PRIME_29_31 = {
+    29: (0xEE51, 0xEE50),
+    31: (0xE2EC, 0xE2ED),
+}
 
 
 def load_cmap(path: Path) -> Dict[int, str]:
@@ -53,50 +50,6 @@ def codepoint_for_glyph(glyph: str) -> int:
         raise ValueError(f"glyph {glyph!r} has multiple scalars: {scalars}")
     return scalars[0]
 
-def glyph_metrics(path: Path, codepoint: int) -> Tuple[int, float]:
-    font = TTFont(path)
-    cmap: Dict[int, str] = {}
-    for table in font["cmap"].tables:
-        cmap.update(table.cmap)
-    name = cmap.get(codepoint)
-    if name is None:
-        return (0, 0.0)
-    width, _ = font["hmtx"][name]
-    pil_font = ImageFont.truetype(str(path), 200)
-    img = Image.new("L", (200, 200), 255)
-    draw = ImageDraw.Draw(img)
-    draw.text((0, 0), chr(codepoint), font=pil_font, fill=0)
-    pixels = img.load()
-    ink = 0
-    total = 200 * 200
-    for y in range(200):
-        for x in range(200):
-            if pixels[x, y] < 128:
-                ink += 1
-    return (width, ink / total)
-
-def summarize_candidate_pairs() -> None:
-    print("Candidate HEJI2 PUA pairs for primes 29/31 (down/up):")
-    aggregate: Dict[Tuple[int, int], Dict[str, Tuple[int, float]]] = {}
-    for pair in PRIME_29_31_CANDIDATE_PAIRS:
-        aggregate[pair] = {}
-        for font_path in FONT_PATHS:
-            widths = [glyph_metrics(font_path, cp)[0] for cp in pair]
-            inks = [glyph_metrics(font_path, cp)[1] for cp in pair]
-            avg_width = int(round(sum(widths) / len(widths)))
-            avg_ink = sum(inks) / len(inks)
-            aggregate[pair][font_path.name] = (avg_width, avg_ink)
-    for pair in PRIME_29_31_CANDIDATE_PAIRS:
-        down, up = pair
-        print(f"  pair=U+{down:04X}/U+{up:04X}")
-        for font_name, (avg_width, avg_ink) in aggregate[pair].items():
-            print(f"    {font_name}: avg_width={avg_width} avg_ink={avg_ink:.4f}")
-    bracket_pair = min(
-        aggregate.items(),
-        key=lambda item: sum(info[1] for info in item[1].values()) / len(item[1])
-    )[0]
-    print(f"Bracket-like (lowest ink) pair: U+{bracket_pair[0]:04X}/U+{bracket_pair[1]:04X}")
-
 
 def main() -> None:
     mapping = json.loads(MAPPING_PATH.read_text())
@@ -122,7 +75,6 @@ def main() -> None:
         down, up = resolved[prime]
         print(f"  prime={prime} down=U+{down:04X} up=U+{up:04X}")
 
-    summarize_candidate_pairs()
     print("Current heji2_mapping.json entries (29/31):")
     for prime in (29, 31):
         entry = primes.get(str(prime), {}).get("1", {})
@@ -132,6 +84,18 @@ def main() -> None:
             down_cp = codepoint_for_glyph(down)
             up_cp = codepoint_for_glyph(up)
             print(f"  prime={prime} down=U+{down_cp:04X} up=U+{up_cp:04X}")
+            expected = EXPECTED_PRIME_29_31[prime]
+            if (down_cp, up_cp) != expected:
+                raise RuntimeError(
+                    f"Unexpected mapping for prime {prime}: "
+                    f"got U+{down_cp:04X}/U+{up_cp:04X}, "
+                    f"expected U+{expected[0]:04X}/U+{expected[1]:04X}"
+                )
+            for cp in expected:
+                if cp not in available_points:
+                    raise RuntimeError(
+                        f"Missing codepoint U+{cp:04X} for prime {prime}"
+                    )
 
 
 if __name__ == "__main__":

--- a/Tenney/Resources/heji2_mapping.json
+++ b/Tenney/Resources/heji2_mapping.json
@@ -35,10 +35,10 @@
         "1": { "up": [{ "glyph": "\uE2EB" }], "down": [{ "glyph": "\uE2EA" }] }
       },
       "29": {
-        "1": { "up": [{ "glyph": "\uE2F1" }], "down": [{ "glyph": "\uE2F0" }] }
+        "1": { "up": [{ "glyph": "\uEE50" }], "down": [{ "glyph": "\uEE51" }] }
       },
       "31": {
-        "1": { "up": [{ "glyph": "\uE2F3" }], "down": [{ "glyph": "\uE2F2" }] }
+        "1": { "up": [{ "glyph": "\uE2ED" }], "down": [{ "glyph": "\uE2EC" }] }
       }
   }
 }

--- a/TenneyTests/HejiPrime29And31FixesTests.swift
+++ b/TenneyTests/HejiPrime29And31FixesTests.swift
@@ -46,6 +46,9 @@ struct HejiPrime29And31FixesTests {
         let prime29Up = mapping.glyphsForPrimeComponents([
             HejiMicrotonalComponent(prime: 29, up: true, steps: 1)
         ])
+        let prime29Down = mapping.glyphsForPrimeComponents([
+            HejiMicrotonalComponent(prime: 29, up: false, steps: 1)
+        ])
         let prime31Up = mapping.glyphsForPrimeComponents([
             HejiMicrotonalComponent(prime: 31, up: true, steps: 1)
         ])
@@ -53,18 +56,29 @@ struct HejiPrime29And31FixesTests {
             HejiMicrotonalComponent(prime: 31, up: false, steps: 1)
         ])
 
-        let prime29Scalar = firstScalar(from: prime29Up)
-        let prime31Scalar = firstScalar(from: prime31Up)
-        #expect(prime29Scalar != nil)
-        #expect(prime31Scalar != nil)
-        #expect(prime29Scalar != prime31Scalar)
+        let prime29UpScalar = firstScalar(from: prime29Up)
+        let prime29DownScalar = firstScalar(from: prime29Down)
+        let prime31UpScalar = firstScalar(from: prime31Up)
+        let prime31DownScalar = firstScalar(from: prime31Down)
+        #expect(prime29UpScalar == 0xEE50)
+        #expect(prime29DownScalar == 0xEE51)
+        #expect(prime31UpScalar == 0xE2ED)
+        #expect(prime31DownScalar == 0xE2EC)
+        #expect(prime29UpScalar != prime31UpScalar)
 
         let bracketScalars: Set<UInt32> = [0xE2EE, 0xE2EF]
-        if let upScalar = prime31Scalar {
+        if let upScalar = prime31UpScalar {
             #expect(!bracketScalars.contains(upScalar))
         }
-        if let downScalar = firstScalar(from: prime31Down) {
+        if let downScalar = prime31DownScalar {
             #expect(!bracketScalars.contains(downScalar))
+        }
+
+        let temperedRange = 0xE2F0...0xE2F6
+        for scalar in [prime29UpScalar, prime29DownScalar, prime31UpScalar, prime31DownScalar] {
+            if let scalar {
+                #expect(!temperedRange.contains(Int(scalar)))
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation
- Prime 29/31 mappings were pointing at tempered/meantone accidental codepoints and need to use their intended glyphs (two-pronged arrow for 29, 31-flag for 31).
- Tests relied on heuristics and could allow regressions; they should assert exact codepoint scalars for these primes.
- The Pillow-based heuristic in the extraction helper added an unnecessary dependency and should be replaced with a deterministic fontTools-only validation.

### Description
- Updated `Tenney/Resources/heji2_mapping.json` to set prime 29 step-1 to `up=\uEE50` / `down=\uEE51` and prime 31 step-1 to `up=\uE2ED` / `down=\uE2EC` without touching other primes or step rows.
- Hardened `TenneyTests/HejiPrime29And31FixesTests.swift` to assert the exact first scalar values for prime-29 and prime-31 glyphs and added an anti-regression guard ensuring none are in the tempered accidental range `0xE2F0...0xE2F6`, while preserving the prime-31 tonic anchoring and prime-11 suppression checks.
- Reverted `Scripts/extract_heji2_prime_glyphs.py` to fontTools-only operation by removing all Pillow code, added an explicit expected-table for primes 29/31, and made the script fail fast if the expected codepoints are not present in the bundled fonts (`HEJI2.otf`, `HEJI2Text.otf`).

### Testing
- No automated test suite was executed as part of this patch.
- Unit tests were updated: `TenneyTests/HejiPrime29And31FixesTests.swift` now asserts exact scalars for primes 29 and 31 and will detect regressions when run in CI.
- The extraction helper `Scripts/extract_heji2_prime_glyphs.py` now performs deterministic checks with `fontTools` and will raise `RuntimeError` if expected codepoints are missing when invoked.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69767cad062c832780966b8202dd62af)