### PR TITLE
Add staff-only octave assist rendering (8va / 8vb)

### DIFF
--- a/Tenney/HejiNotation.swift
+++ b/Tenney/HejiNotation.swift
@@ -513,6 +513,18 @@ enum HejiNotation {
 
     // MARK: - Staff layout helpers
 
+    /// Shared staff-step mapping for renderer-only helpers.
+    static func staffStepFromMiddleForRendering(letter: String, octave: Int, clef: HejiStaffLayout.Clef) -> Int {
+        staffStepFromMiddle(letter: letter, octave: octave, clef: clef)
+    }
+
+    /// Staff-step span for one octave, based on the same diatonic mapping used by staff layout.
+    static func staffStepSpanForOctave(clef: HejiStaffLayout.Clef, referenceLetter: String = "C", referenceOctave: Int = 4) -> Int {
+        let base = staffStepFromMiddle(letter: referenceLetter, octave: referenceOctave, clef: clef)
+        let upper = staffStepFromMiddle(letter: referenceLetter, octave: referenceOctave + 1, clef: clef)
+        return upper - base
+    }
+
     private static func autoClef(forOctave octave: Int) -> HejiStaffLayout.Clef {
         // Heuristic: treble at middle C (C4) and above; bass below.
         return octave >= 4 ? .treble : .bass


### PR DESCRIPTION
### Motivation
- Reduce far ledger lines when drawing staff glyphs by displaying out-of-range pitches one octave toward the staff with an octave mark. 
- The transform must be purely visual and apply only when rendering in staff mode, without changing pitch identity, audio, labels, or layout measurements.

### Description
- Added renderer helpers `staffStepFromMiddleForRendering` and `staffStepSpanForOctave` in `HejiNotation` to derive threshold steps and an octave span using the existing diatonic staff-step mapping. 
- Implemented an internal `OctaveAssist` type and `octaveAssist` helper inside `HejiStaffSnippetView` that returns `writtenStep`, `shiftOctaves`, and optional `mark` by comparing the original step to A5 (treble) and G2 (bass) thresholds. 
- Applied `assist.writtenStep` to compute notehead y-position and ledger-line drawing while leaving all non-staff outputs untouched, and render a small `"8va"` or `"8vb"` mark positioned above/below the staff as an overlay. 
- Added a `#if DEBUG` SwiftUI preview that includes cases to visually verify in-staff notes and triggering treble/bass assists, and included comments clarifying this is a display-only staff-mode transform.

### Testing
- No automated test suite was executed as part of this change. 
- Added debug SwiftUI previews under `HejiStaffSnippetView` to visually validate: in-staff notes (no assist), treble case triggering `8va`, and bass case triggering `8vb`. 
- Manual verification steps: launch the app or previews in staff mode and confirm notes above A5 (treble) render written down one octave with `8va`, notes below G2 (bass) render written up one octave with `8vb`, and all other UI (labels, audio, info card layout) remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976c6c9b71c83279fdf1b39ad2eca2b)