### PR TITLE
Extend staff octave assist to three octaves

### DIFF
--- a/Tenney/HejiStaffSnippetView.swift
+++ b/Tenney/HejiStaffSnippetView.swift
@@ -62,16 +62,36 @@ struct HejiStaffSnippetView: View {
 
         switch clef {
         case .treble:
-            if originalStep > trebleMaxStep {
-                return OctaveAssist(writtenStep: originalStep - octaveSteps, shiftOctaves: 1, mark: "8va")
+            var writtenStep = originalStep
+            var shifts = 0
+            while writtenStep > trebleMaxStep && shifts < 3 {
+                writtenStep -= octaveSteps
+                shifts += 1
             }
+            let mark: String?
+            switch shifts {
+            case 1: mark = "8va"
+            case 2: mark = "15ma"
+            case 3: mark = "22ma"
+            default: mark = nil
+            }
+            return OctaveAssist(writtenStep: writtenStep, shiftOctaves: shifts, mark: mark)
         case .bass:
-            if originalStep < bassMinStep {
-                return OctaveAssist(writtenStep: originalStep + octaveSteps, shiftOctaves: -1, mark: "8vb")
+            var writtenStep = originalStep
+            var shifts = 0
+            while writtenStep < bassMinStep && shifts < 3 {
+                writtenStep += octaveSteps
+                shifts += 1
             }
+            let mark: String?
+            switch shifts {
+            case 1: mark = "8vb"
+            case 2: mark = "15mb"
+            case 3: mark = "22mb"
+            default: mark = nil
+            }
+            return OctaveAssist(writtenStep: writtenStep, shiftOctaves: -shifts, mark: mark)
         }
-
-        return OctaveAssist(writtenStep: originalStep, shiftOctaves: 0, mark: nil)
     }
 
     var body: some View {
@@ -165,16 +185,18 @@ struct HejiStaffSnippetView_Previews: PreviewProvider {
             Text("Treble")
                 .font(.caption.weight(.semibold))
             HStack(spacing: 12) {
-                HejiStaffSnippetView(layout: previewLayout(letter: "C", octave: 5, clef: .treble))
-                HejiStaffSnippetView(layout: previewLayout(letter: "B", octave: 5, clef: .treble))
-                HejiStaffSnippetView(layout: previewLayout(letter: "G", octave: 5, clef: .treble))
+                HejiStaffSnippetView(layout: previewLayout(letter: "A", octave: 5, clef: .treble))
+                HejiStaffSnippetView(layout: previewLayout(letter: "C", octave: 6, clef: .treble))
+                HejiStaffSnippetView(layout: previewLayout(letter: "E", octave: 7, clef: .treble))
+                HejiStaffSnippetView(layout: previewLayout(letter: "G", octave: 8, clef: .treble))
             }
             Text("Bass")
                 .font(.caption.weight(.semibold))
             HStack(spacing: 12) {
-                HejiStaffSnippetView(layout: previewLayout(letter: "D", octave: 3, clef: .bass))
-                HejiStaffSnippetView(layout: previewLayout(letter: "F", octave: 2, clef: .bass))
-                HejiStaffSnippetView(layout: previewLayout(letter: "A", octave: 2, clef: .bass))
+                HejiStaffSnippetView(layout: previewLayout(letter: "G", octave: 2, clef: .bass))
+                HejiStaffSnippetView(layout: previewLayout(letter: "E", octave: 2, clef: .bass))
+                HejiStaffSnippetView(layout: previewLayout(letter: "C", octave: 1, clef: .bass))
+                HejiStaffSnippetView(layout: previewLayout(letter: "A", octave: 0, clef: .bass))
             }
         }
         .padding()


### PR DESCRIPTION
### Motivation

- Ensure no note renders outside the 5-line staff region by extending the existing staff-only octave folding from one octave to up to three octaves while keeping this strictly a display-only transform.

### Description

- Replace the single-octave logic in `octaveAssist(clef:originalStep:)` with an iterative fold that applies 1–3 octave shifts using `HejiNotation.staffStepSpanForOctave(clef:)` and the existing `trebleMaxStep` / `bassMinStep` thresholds. 
- Map number of shifts to the correct mark strings (`treble: 1→"8va", 2→"15ma", 3→"22ma"`; `bass: 1→"8vb", 2→"15mb", 3→"22mb"`) and preserve `shiftOctaves` semantics (`+shifts` for treble, `-shifts` for bass). 
- Preserve rendering behavior by continuing to compute `y` from `assist.writtenStep`, passing `assist.writtenStep` into `drawLedgerLines(...)`, and drawing the mark with the existing placement; ledger line drawing logic itself is unchanged. 
- Add extra DEBUG preview cases in `HejiStaffSnippetView_Previews` to visually exercise extreme treble and bass cases for `8va/15ma/22ma` and `8vb/15mb/22mb` without affecting production code.

### Testing

- Attempted an automated build with `xcodebuild -scheme Tenney -destination 'platform=iOS Simulator,name=iPhone 14' build`, but the command failed in this environment because `xcodebuild` is not available. 
- No other automated tests were executed in this environment; preview additions are under `#if DEBUG` for local visual verification in Xcode. 
- Manual UI verification is recommended: build in Xcode and confirm existing `8va/8vb` cases remain unchanged, extreme notes render `15m/22m` marks as expected, and no behavior outside the staff snippet renderer is modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976cf94a4b08327b70b99065e769ea6)