### PR TITLE
Fix ActionTile tap target to cover full tile

### DIFF
--- a/Tenney/ScaleLibrarySheet.swift
+++ b/Tenney/ScaleLibrarySheet.swift
@@ -2868,6 +2868,7 @@ private struct ActionTile: View {
                     glassLayer
                 }
             }
+        .contentShape(shape)
         .overlay(
             shape.stroke(
                 resolved.isDestructive ? Color.white.opacity(0.35) : Color.secondary.opacity(0.15),
@@ -2896,6 +2897,37 @@ private struct ActionTile: View {
         }
     }
 }
+
+#if DEBUG
+struct ActionTileTapArea_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 16) {
+            ActionTile(
+                title: "Open",
+                systemImage: "square.stack.3d.up.fill",
+                style: .standard(.accentColor)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(Color.red.opacity(0.6), lineWidth: 1)
+            )
+
+            ActionTile(
+                title: "Delete",
+                systemImage: "trash",
+                subtitle: "Destructive action",
+                style: .destructive
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(Color.red.opacity(0.6), lineWidth: 1)
+            )
+        }
+        .padding()
+        .previewLayout(.sizeThatFits)
+    }
+}
+#endif
 
 private struct RatioChip: View {
     let ratio: RatioRef


### PR DESCRIPTION
### Motivation
- Fix a SwiftUI hit-testing bug where `ActionTile` visuals in the Scale Actions sheet looked like full cards but only the icon/text area was tappable, so tapping the padded/background area did not activate the wrapped `Button`/`Menu`.

### Description
- Add a matching content shape to `ActionTile` by applying `.contentShape(shape)` so the tappable region exactly matches the rounded-rectangle tile background, and include a DEBUG-only `ActionTileTapArea_Previews` to visually validate bounds; the change is limited to `Tenney/ScaleLibrarySheet.swift` and preserves all existing visuals and styles.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976f0d5e5148327b758c9bd799e596a)