### PR TITLE
Extend lattice visuals under top safe area

### DIFF
--- a/Tenney/LatticeView.swift
+++ b/Tenney/LatticeView.swift
@@ -3991,6 +3991,7 @@ struct LatticeView: View {
         ZStack {
             canvasLayer(viewRect: viewRect)
                 .allowsHitTesting(false)
+                .ignoresSafeArea(.container, edges: .top)
 #if os(macOS) || targetEnvironment(macCatalyst)
                 .overlay(alignment: .topLeading) {
                     LatticeTrackpadBridge(
@@ -4205,6 +4206,7 @@ struct LatticeView: View {
             )
             ZStack {
                 background
+                    .ignoresSafeArea(.container, edges: .top)
             
                 latticeStack(in: geo)
                     .sensoryFeedback(.selection, trigger: selectionHapticTick)


### PR DESCRIPTION
### Motivation
- Let the lattice background and renderer visuals extend beneath the top safe area so the lattice fills behind the status bar / notch while preserving all overlay layout and tap behavior.

### Description
- In `Tenney/LatticeView.swift` add `.ignoresSafeArea(.container, edges: .top)` to the visual layers — the renderer (`canvasLayer(...)`) and the scene background (`TenneySceneBackground`) — so only those visual layers extend under the top safe area while overlay UI and hit-testing remain unchanged.

### Testing
- Attempted to build for iOS and Mac Catalyst with `xcodebuild` but `xcodebuild` is not available in this environment, so automated builds could not be executed here and no automated test failures were produced locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976ff318a3c832799c649d04db1fb34)