### PR TITLE
Fix distance chip overlay hit testing

### DIFF
--- a/Tenney/LatticeView.swift
+++ b/Tenney/LatticeView.swift
@@ -4476,7 +4476,7 @@ struct LatticeView: View {
                     }
                 }
             
-                .overlay { tenneyOverlay }
+                .overlay(alignment: .topLeading) { tenneyOverlay }
                 .onChange(of: latticePreviewMode) { isPreview in
                     if isPreview { bottomHUDHeight = 0 }
                 }
@@ -5670,6 +5670,13 @@ struct LatticeView: View {
         let model: DistanceDetailSheet.Model?
     }
 
+    private struct TenneyDistanceChipStackSizeKey: PreferenceKey {
+        static var defaultValue: CGSize = .zero
+        static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+            value = nextValue()
+        }
+    }
+
     private struct TenneyDistanceOverlay: View {
         let a: TenneyDistanceNode
         let b: TenneyDistanceNode
@@ -5677,6 +5684,8 @@ struct LatticeView: View {
         let totalChip: DistanceChipDetail
         let breakdownChips: [DistanceChipDetail]
         let presentDetail: (DistanceDetailSheet.Model) -> Void
+
+        @State private var chipStackSize: CGSize = .zero
 
         var body: some View {
             let A = a.screen
@@ -5691,7 +5700,7 @@ struct LatticeView: View {
             let ny =  vx / len
             let anchor = CGPoint(x: mid.x + nx * 16, y: mid.y + ny * 16)
 
-            VStack(spacing: 6) {
+            let chipStack = VStack(spacing: 6) {
                 tappableChip(totalChip)
 
                 if mode == .breakdown, !breakdownChips.isEmpty {
@@ -5703,7 +5712,21 @@ struct LatticeView: View {
                 }
             }
             .fixedSize()
-            .position(anchor)
+            .background(
+                GeometryReader { proxy in
+                    Color.clear.preference(
+                        key: TenneyDistanceChipStackSizeKey.self,
+                        value: proxy.size
+                    )
+                }
+            )
+            .onPreferenceChange(TenneyDistanceChipStackSizeKey.self) { chipStackSize = $0 }
+
+            chipStack
+                .offset(
+                    x: anchor.x - chipStackSize.width * 0.5,
+                    y: anchor.y - chipStackSize.height * 0.5
+                )
         }
 
         @ViewBuilder


### PR DESCRIPTION
### Motivation
- The distance overlay attached via `.overlay { tenneyOverlay }` and positioned with `.position(anchor)` created a full-screen interactive layer that intercepted all lattice taps and gestures.
- The intent is to keep distance chips tappable while preventing the overlay from stealing hit-testing across the lattice without changing existing lattice gestures, selection, camera, or hit-test logic.

### Description
- Change overlay attachment from `.overlay { tenneyOverlay }` to `.overlay(alignment: .topLeading) { tenneyOverlay }` so the overlay is aligned to a top-left origin and no longer implicitly spans the whole lattice.
- Add a file-local `TenneyDistanceChipStackSizeKey: PreferenceKey` and a `@State private var chipStackSize: CGSize` inside `TenneyDistanceOverlay` to measure the chip stack size without introducing a full-screen `GeometryReader` hit target.
- Replace `.position(anchor)` with an anchored offset computed from the measured stack size using `chipStack.offset(x: anchor.x - chipStackSize.width * 0.5, y: anchor.y - chipStackSize.height * 0.5)` so the hit-test region is limited to the visible chip capsules.
- Keep chip tap handling unchanged by retaining the existing `tappableChip(...)` helper (`GlassChip + contentShape(Capsule()) + onTapGesture`) and avoid adding gestures to the container stack or introducing full-screen `Color.clear` hit targets.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977186ede8483279c64033d368aeeb5)