### PR TITLE
Adjust iPhone landscape lattice layout

### DIFF
--- a/Tenney/UtilityBarHeightEnvironment.swift
+++ b/Tenney/UtilityBarHeightEnvironment.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+private struct UtilityBarHeightKey: EnvironmentKey {
+    static let defaultValue: CGFloat = 0
+}
+
+extension EnvironmentValues {
+    var utilityBarHeight: CGFloat {
+        get { self[UtilityBarHeightKey.self] }
+        set { self[UtilityBarHeightKey.self] = newValue }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an iPhone-landscape-only presentation layout that extends the lattice into side unsafe areas while preserving existing hit-testing and selection behavior.
- Make the UtilityBar a floating, content-hugging capsule in landscape to avoid full-width stretching.
- Slightly nudge overlay chips up, collapse AxisShift HUD into a compact “Axis” pill in landscape, center the info card vertically between utility and bottom HUD, and reduce SelectionTray footprint in landscape.

### Description
- Add an `isPhoneLandscape` gate in `LatticeView` (via `@Environment(\.verticalSizeClass)`) and a `LandscapeSideUnsafe` ViewModifier, and apply it at the root containing the `GeometryReader` so horizontal safe areas are ignored only on iPhone landscape (with an inline comment warning not to move `.ignoresSafeArea` into `latticeStack`).
- Move chips overlay padding to use small landscape-only deltas (`.padding(.leading, 10)`, vertical top padding reduced to `6`) so chips are slightly higher and inset from bezel without changing hit-testing semantics.
- Add `InfoCardHeightKey` and measure `utilityBarHeight` (propagated via a new environment key `utilityBarHeight`) to compute an available vertical band and vertically center the info card in landscape; the info card height is measured and used only for layout/offset, with animations respecting Reduce Motion.
- Add a compact `AxisShiftPill` (reuses existing `AxisShiftProSheet`) and show it in place of `AxisShiftHUD` when `isPhoneLandscape` is true, preserving the same presentation mechanism and state.
- Make `SelectionTray` accept an `isPhoneLandscape` flag and reduce its sizing: `ctl` → 34 in landscape and `trayPadV` reduced, and hide the builder session rail in landscape (rail still shown on other idioms/sizes).
- Restyle `UtilityBar` to render a floating capsule in iPhone landscape (remove expanding `Spacer()` behavior, use a compact `HStack(spacing: 10)` that `.fixedSize(horizontal: true, vertical: true)` and apply glass/stroke/shadow styling) while leaving portrait/iPad/macOS behavior unchanged.
- Files changed (surgical edits): `Tenney/LatticeView.swift`, `Tenney/ContentView.swift`, and a small `Tenney/UtilityBarHeightEnvironment.swift` environment-key helper.

### Testing
- Automated tests: none were executed as part of this change (no CI/unit/UI tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69772fba47f08327bb953a9743339203)