### PR TITLE
Fix lock target sheet actions and toolbar

### DIFF
--- a/Tenney/Views/LockTargetSheet.swift
+++ b/Tenney/Views/LockTargetSheet.swift
@@ -83,6 +83,21 @@ struct LockTargetSheet: View {
             }
             .navigationTitle("Lock Target")
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        onCancel()
+                    } label: {
+                        Image(systemName: "checkmark")
+                            .font(.headline.weight(.semibold))
+                            .frame(width: 32, height: 32)
+                            .contentShape(Circle())
+                    }
+                    .buttonStyle(.plain)
+                    .modifier(GlassBlueCircle())
+                    .accessibilityLabel("Done")
+                }
+            }
         }
     }
 
@@ -344,13 +359,18 @@ struct LockTargetSheet: View {
                 .disabled(!isValid)
                 .opacity(isValid ? 1 : 0.6)
 
-                glassActionButton(title: "Lock", systemImage: "lock.fill", action: {
+                glassActionButton(
+                    title: "Lock",
+                    systemImage: "lock.fill",
+                    usesRedStyle: true,
+                    action: {
                     guard let preview = lockPreview else { return }
                     onCommit(preview)
 #if os(iOS) && !targetEnvironment(macCatalyst)
                     UINotificationFeedbackGenerator().notificationOccurred(.success)
 #endif
-                })
+                    }
+                )
                 .disabled(!isValid)
                 .opacity(isValid ? 1 : 0.6)
             }
@@ -503,12 +523,15 @@ private extension LockTargetSheet {
         systemImage: String,
         tint: Color? = nil,
         isDestructive: Bool = false,
+        usesRedStyle: Bool = false,
         minHeight: CGFloat = 44,
         horizontalPadding: CGFloat = 14,
         fillsWidth: Bool = true,
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
+            let corner: CGFloat = 12
+            let redStyle = isDestructive || usesRedStyle
             let label = HStack(spacing: 6) {
                 Image(systemName: systemImage)
                 Text(title)
@@ -516,15 +539,16 @@ private extension LockTargetSheet {
             }
             .frame(maxWidth: fillsWidth ? .infinity : nil, minHeight: minHeight)
             .padding(.horizontal, horizontalPadding)
-            .foregroundStyle(isDestructive ? .white : (tint ?? .primary))
+            .foregroundStyle(redStyle ? .white : (tint ?? .primary))
 
             Group {
-                if isDestructive {
-                    label.modifier(GlassRedRoundedRect(corner: 12))
+                if redStyle {
+                    label.modifier(GlassRedRoundedRect(corner: corner))
                 } else {
-                    label.modifier(GlassRoundedRect(corner: 12))
+                    label.modifier(GlassRoundedRect(corner: corner))
                 }
             }
+            .contentShape(RoundedRectangle(cornerRadius: corner, style: .continuous))
         }
         .buttonStyle(GlassPressFeedback())
     }


### PR DESCRIPTION
### Motivation
- Ensure the bottom action buttons (`Cancel` / `Set` / `Lock`) are fully tappable across their full rounded background area.
- Make the `Lock` action visually use the app’s existing red glass styling rather than inventing new colors.
- Add a top-right checkmark toolbar dismiss button that uses the existing `GlassBlueCircle` styling and calls `onCancel()`.

### Description
- Added a toolbar `ToolbarItem(placement: .topBarTrailing)` with a `Button` that calls `onCancel()` and applies `.modifier(GlassBlueCircle())` to match existing app chrome styling.
- Extended the helper `glassActionButton(...)` in `LockTargetSheet` with a new parameter `usesRedStyle: Bool = false` and compute `redStyle = isDestructive || usesRedStyle` so the `Lock` button can use `GlassRedRoundedRect` without changing semantic destructive behavior.
- Improved hit-testing for glass action buttons by introducing a `corner` constant and applying `.contentShape(RoundedRectangle(cornerRadius: corner, style: .continuous))` at the outer label level so the full visible rounded rect is tappable.

### Testing
- No automated tests were executed for this change (UI-only modifications); recommend manual verification on iPhone/iPad/Catalyst/macOS that the `Cancel`/`Set`/`Lock` buttons are tappable across their full surfaces, the `Lock` button appears with the red glass style, and the top-right checkmark dismisses the sheet.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69774566b3a08327ac3f446313273545)