### PR TITLE
Remove lock-sheet top-right dismiss and add cooldown gate to prevent immediate re-open

### DIFF
--- a/Tenney/ContentView.swift
+++ b/Tenney/ContentView.swift
@@ -1479,6 +1479,7 @@ extension Notification.Name {
                 }
             }
             .onReceive(NotificationCenter.default.publisher(for: .tunerOpenLockSheet)) { _ in
+                guard !TunerLockSheetGate.shouldIgnoreOpen() else { return }
                 showLockSheet = true
             }
             .sheet(isPresented: $showLockSheet) {
@@ -2399,6 +2400,7 @@ private struct UtilityBar: View {
                 width: tunerLockPillWidth,
                 matchedGeometry: nil
             ) {
+                guard !TunerLockSheetGate.shouldIgnoreOpen() else { return }
                 NotificationCenter.default.post(name: .tunerOpenLockSheet, object: nil)
             }
             .frame(width: tunerLockPillWidth)

--- a/Tenney/TunerLockSheetGate.swift
+++ b/Tenney/TunerLockSheetGate.swift
@@ -1,0 +1,13 @@
+import QuartzCore
+
+enum TunerLockSheetGate {
+    private static var ignoreUntil: CFTimeInterval = 0
+
+    static func armCooldown(seconds: CFTimeInterval = 0.6) {
+        ignoreUntil = CACurrentMediaTime() + seconds
+    }
+
+    static func shouldIgnoreOpen() -> Bool {
+        CACurrentMediaTime() < ignoreUntil
+    }
+}

--- a/Tenney/Views/LockTargetSheet.swift
+++ b/Tenney/Views/LockTargetSheet.swift
@@ -98,14 +98,6 @@ struct LockTargetSheet: View {
             }
             .navigationTitle("Lock Target")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                            ToolbarItem(placement: .topBarTrailing) {
-                                GlassDismissCircleButton {
-                                    handleCancel()
-                                }
-                                .disabled(isDismissing)
-                            }
-                        }
         }
     }
 
@@ -117,7 +109,9 @@ struct LockTargetSheet: View {
                 minHeight: 32,
                 horizontalPadding: 12,
                 fillsWidth: false,
-                action: onUnlock
+                action: {
+                    requestDismiss(onUnlock)
+                }
             )
         }
     
@@ -416,6 +410,7 @@ struct LockTargetSheet: View {
             guard !isDismissing else { return }
             isDismissing = true
             focusedField = nil
+            TunerLockSheetGate.armCooldown(seconds: 0.6)
     
             // Prevent immediate re-trigger / tap-through / re-entrant state coupling.
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {


### PR DESCRIPTION
### Motivation
- Remove the top-right checkmark dismiss control from the lock sheet so the sheet is dismissible only via the bottom action bar or system gestures.
- Prevent a re-entrant reopen bug on iPhone landscape tuner where tapping Cancel (or dismissing) could immediately re-open the sheet due to tap-through / notification coupling.
- Implement a small, shared open-cooldown to robustly ignore open triggers for a short window after dismiss.

### Description
- Removed the `GlassDismissCircleButton` toolbar item from `Tenney/Views/LockTargetSheet.swift` so the top-right checkmark is no longer shown.
- Added a tiny shared helper `Tenney/TunerLockSheetGate.swift` with `armCooldown(seconds:)` and `shouldIgnoreOpen()` using `CACurrentMediaTime()` to coordinate a cooldown window (~0.6s).
- Armed the gate from `LockTargetSheet.requestDismiss` (called by `Cancel`, `Set`, `Lock`, and `Unlock` paths) by calling `TunerLockSheetGate.armCooldown(seconds: 0.6)` before performing the dismiss work.
- Guarded both the open-notification post in `UtilityBar` lock pill and the notification receive in `TunerCard` (`Tenney/ContentView.swift`) with `guard !TunerLockSheetGate.shouldIgnoreOpen() else { return }` to block reopen events during the cooldown.

### Testing
- No automated tests were added or executed as part of this change.
- The change compiles locally in the development environment used for the edit (no compile warnings/errors were introduced by the edits).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69774e6ddaac8327a40ec38a2cb4965c)