### PR TITLE
Prevent lattice long-press drift; add gesture guards and debug logging

### DIFF
--- a/Tenney/LatticeDebug.swift
+++ b/Tenney/LatticeDebug.swift
@@ -1,0 +1,11 @@
+//  LatticeDebug.swift
+//  Tenney
+//
+//  Shared debug toggles for lattice diagnostics.
+//
+
+import Foundation
+
+enum LatticeDebug {
+    static let gestureLoggingEnabled = false
+}


### PR DESCRIPTION
### Motivation
- Repro showed a selection-dependent drift: a press-and-hold on a different node mutated view state (pivot/camera) and caused subsequent taps to hit the wrong node, so long-press must not mutate camera/origin/basis. 
- Pan should not begin on touch-down (no zero-distance drift) and selection state must not change hit-test transform in ways that cause ±1 shifts. 
- Add high-signal logs (behind a feature flag) to prove gesture ordering and any camera/state mutations during repro. 

### Description
- Stop the selection-dependent long-press from mutating pivot/camera by making the long-press a non-mutation context gesture and driving it from the current touch-down location rather than stale tap context; see `Tenney/LatticeView.swift` (`longPresser` and `gestureCatcher`).
- Add transient press tracking (`lastPressPoint`, `pressingNode`) and a touch-down capture (`DragGesture(minimumDistance: 0)`) so gestures have a single source-of-truth press position and so node long-press is mutually exclusive with panning; see `Tenney/LatticeView.swift` (press state + pan gating changes).
- Require a real pan threshold and gate camera panning until threshold is crossed, and ensure panning clears press state when it takes over; see `panGesture()` modifications in `Tenney/LatticeView.swift`.
- Make hit-testing and rendering use the same transform source (camera via `store.camera`) and add hit-test logs that include camera/pivot/axisShift context; see `hitTestCandidate` enhancements in `Tenney/LatticeView.swift`.
- Add a small shared debug toggle `Tenney/LatticeDebug.swift` and wire high-signal debug printing for gestures/camera/selection transitions; see `LatticeDebug.gestureLoggingEnabled` and multiple `#if DEBUG` logs in `Tenney/LatticeView.swift` and `Tenney/LatticeStore.swift`.
- Extend selection APIs to carry a `reason` (`tap|longPress|drag|program`) and log selection transitions and axis/shift changes from `LatticeStore` for traceability; see `Tenney/LatticeStore.swift` (`SelectionChangeReason`, `toggleSelection`, `toggleOverlay`, logging helpers, and `setPivot` changes).
- Minor behavioral changes: `brushGesture` now reports `reason: .drag` when toggling selections so logs reflect source.

### Testing
- Automated tests: none executed in this change; no unit/UI tests were run as part of this PR. 
- Manual verification plan (recommended): repro the original sequence (select node A, press-and-hold node B) with `LatticeDebug.gestureLoggingEnabled = true` and confirm logs show gesture ordering, that no `[CAM]` entries are emitted during node long-press, that panning only starts after the movement threshold, and that subsequent taps hit the correct node at 2 zoom levels and on both iPad/macCatalyst.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977af85b8e88327b54ddda370c80b0f)