### PR TITLE
Present DistanceDetailSheet from Tenney distance chips (Button-only taps)

### DIFF
--- a/Tenney/DistanceDetailSheet.swift
+++ b/Tenney/DistanceDetailSheet.swift
@@ -1,0 +1,33 @@
+//
+//  DistanceDetailSheet.swift
+//  Tenney
+//
+//  Created by Codex.
+//
+
+import SwiftUI
+
+struct DistanceDetailSheet: View {
+    struct Model: Identifiable {
+        let id: UUID = UUID()
+        let fromLabel: String
+        let toLabel: String
+        let metricText: String
+        let tint: Color
+    }
+
+    let model: Model
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("From \(model.fromLabel) → \(model.toLabel)")
+                .font(.headline)
+                .multilineTextAlignment(.center)
+
+            GlassChip(text: model.metricText, tint: model.tint)
+
+            Spacer(minLength: 0)
+        }
+        .padding(20)
+    }
+}


### PR DESCRIPTION
### Motivation
- When exactly two plane nodes are selected, tapping any visible Tenney distance "chip" should present the existing DistanceDetailSheet as a bottom sheet using the exact metric text already shown on the chip. 
- Keep changes narrowly scoped so selection ordering, axis/camera behavior, hit-testing, and existing gesture semantics are not regressed.
- Ensure chips remain plain Buttons (no new gestures) to avoid reintroducing the lattice axis-shift / hit-test offset bug.

### Description
- Wired a stable sheet state into `LatticeView` with `@State private var activeDistanceDetail: DistanceDetailSheet.Model?` and attached `.sheet(item: $activeDistanceDetail)` near the root of `LatticeView` to present the sheet with `.presentationDetents([.medium, .large])`, `.presentationDragIndicator(.visible)`, and a conditional `presentationBackground` that respects `accessibilityReduceTransparency`.
- Extended the internal `TenneyDistanceOverlay` declaration to accept `fromLabel`, `toLabel`, and a `presentDetail: (DistanceDetailSheet.Model) -> Void` callback so the overlay remains presentational and does not own presentation state.
- Converted every distance chip in `TenneyDistanceOverlay` into a plain `Button` that uses `.buttonStyle(.plain)` and `.contentShape(Capsule())`, triggers a light UIKit haptic on tap where available, and invokes `presentDetail(...)` with a `DistanceDetailSheet.Model` built from the exact display text used by the chip (no separate math pipeline).
- Added `Tenney/DistanceDetailSheet.swift` with an `Identifiable` `Model` convenience container and a minimal view that renders a "From → To" header (using the same ordered pair from `store.selectedPair()`) and the chip metric string.

### Testing
- Attempted CI/local builds: ran the mandated `xcodebuild` commands but `xcodebuild` is not available in this environment so automated builds could not be executed and therefore did not complete.
- Reasoned-through manual sanity checklist: selecting exactly two plane nodes still shows the overlay; tapping any chip will call the overlay-provided callback which presents the sheet using the chip's displayed metric text; dismissing the sheet has no side-effects on selection/camera/axis because sheet state is owned by `LatticeView`; info card and lattice rendering code were not modified.
- Files changed: `Tenney/LatticeView.swift` (wiring, overlay callback, buttonized chips, haptics, sheet presentation) and `Tenney/DistanceDetailSheet.swift` (new small view + `Model: Identifiable`).
- Why this is safe: changes are intentionally limited to `LatticeView` and a small `DistanceDetailSheet` addition; selection logic and `LatticeStore` were only read (used `selectedPair()`), no gestures were added anywhere in the lattice hierarchy, all chip interactions are plain Buttons, and the sheet state is stored at a stable location in `LatticeView` (so camera/axis/selection hit-testing behavior is not affected).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977b962f94483278153b25dedbbd25f)