### PR TITLE
Fix distance ratio and cents display (canonicalize monzo-derived ratios)

### DIFF
--- a/Tenney/LatticeView.swift
+++ b/Tenney/LatticeView.swift
@@ -4392,7 +4392,7 @@ struct LatticeView: View {
                     theme: activeTheme,
                     fromLabel: fromLabel,
                     toLabel: toLabel,
-                    referenceHz: app.rootHz,
+                    referenceA4Hz: concertA4Hz,
                     presentDetail: { activeDistanceDetail = $0 }
                 )
             }
@@ -5788,7 +5788,7 @@ struct LatticeView: View {
         let theme: LatticeTheme
         let fromLabel: String
         let toLabel: String
-        let referenceHz: Double?
+        let referenceA4Hz: Double?
         let presentDetail: (DistanceDetailSheet.Model) -> Void
 
         var body: some View {
@@ -5818,6 +5818,8 @@ struct LatticeView: View {
             let chips = makeChipMetrics(H: H, primeDeltas: primeDeltas)
             let endpoints = makeEndpoints()
             let rows = makeRows(delta: delta, H: H, endpoints: endpoints)
+            let melodicRatioText = melodicRatioDisplayText(delta: delta)
+            let melodicCentsValue = melodicCents(delta: delta)
 
             VStack(spacing: 6) {
                 // Total (always visible when not .off)
@@ -5828,7 +5830,9 @@ struct LatticeView: View {
                             chips: chips,
                             rows: rows,
                             primeDeltas: primeDeltas,
-                            endpoints: endpoints
+                            endpoints: endpoints,
+                            melodicRatioText: melodicRatioText,
+                            melodicCentsValue: melodicCentsValue
                         )
                     )
                 } label: {
@@ -5848,7 +5852,9 @@ struct LatticeView: View {
                                         chips: chips,
                                         rows: rows,
                                         primeDeltas: primeDeltas,
-                                        endpoints: endpoints
+                                        endpoints: endpoints,
+                                        melodicRatioText: melodicRatioText,
+                                        melodicCentsValue: melodicCentsValue
                                     )
                                 )
                             } label: {
@@ -5894,7 +5900,9 @@ struct LatticeView: View {
             chips: [DistanceDetailSheet.ChipMetric],
             rows: [DistanceDetailSheet.MetricRow],
             primeDeltas: [DistanceDetailSheet.PrimeDelta],
-            endpoints: (from: DistanceDetailSheet.Endpoint, to: DistanceDetailSheet.Endpoint)
+            endpoints: (from: DistanceDetailSheet.Endpoint, to: DistanceDetailSheet.Endpoint),
+            melodicRatioText: String,
+            melodicCentsValue: Double?
         ) -> DistanceDetailSheet.Model {
             DistanceDetailSheet.Model(
                 id: UUID(),
@@ -5904,7 +5912,9 @@ struct LatticeView: View {
                 chips: chips,
                 rows: rows,
                 primeDeltas: primeDeltas,
-                referenceHz: referenceHz,
+                referenceA4Hz: referenceA4Hz,
+                melodicRatioText: melodicRatioText,
+                melodicCentsValue: melodicCentsValue,
                 tint: .accentColor
             )
         }
@@ -5916,7 +5926,7 @@ struct LatticeView: View {
         }
 
         private func endpointModel(label: String, exps: [Int:Int]) -> DistanceDetailSheet.Endpoint {
-            let ratioComponents = ratioFromMonzo(exps)
+            let ratioComponents = ratioFromMonzo(exps).map { RatioMath.canonicalPQUnit($0.p, $0.q) }
             let ratioText = ratioComponents.map { RatioMath.unitLabel($0.p, $0.q) } ?? "—"
             let pitchLabel = label != ratioText ? label : nil
             return DistanceDetailSheet.Endpoint(
@@ -5986,12 +5996,11 @@ struct LatticeView: View {
             H: Double,
             endpoints: (from: DistanceDetailSheet.Endpoint, to: DistanceDetailSheet.Endpoint)
         ) -> [DistanceDetailSheet.MetricRow] {
-            let melodicRatio = ratioFromMonzo(delta).map { "\($0.p)/\($0.q)" } ?? "—"
-            let centsValue = ratioFromMonzo(delta).map { RatioMath.centsForRatio($0.p, $0.q) } ?? .nan
+            let melodicRatio = melodicRatioDisplayText(delta: delta)
+            let centsValue = melodicCents(delta: delta)
             let centsText = centsValue.isFinite ? String(format: "%+.1f¢", centsValue) : "—"
             let primeSummary = makePrimeSummary(delta)
-            let freqText = frequencyDeltaText(endpoints: endpoints, referenceHz: referenceHz) ?? "—"
-            let freqFootnote: String? = (referenceHz == nil || freqText == "—") ? "Needs reference pitch" : nil
+            let freqText = frequencyDeltaText(endpoints: endpoints, referenceHz: referenceA4Hz) ?? "—"
 
             return [
                 DistanceDetailSheet.MetricRow(
@@ -6012,7 +6021,7 @@ struct LatticeView: View {
                     id: "freq-delta",
                     label: "Frequency Δ",
                     valueText: freqText,
-                    footnote: freqFootnote,
+                    footnote: nil,
                     copyText: freqText
                 ),
                 DistanceDetailSheet.MetricRow(
@@ -6039,6 +6048,18 @@ struct LatticeView: View {
                 return primeDeltaText(prime: prime, exp: exp)
             }
             return summary.isEmpty ? "—" : summary.joined(separator: " · ")
+        }
+
+        private func melodicRatioDisplayText(delta: [Int:Int]) -> String {
+            ratioFromMonzo(delta)
+                .map { RatioMath.canonicalPQUnit($0.p, $0.q) }
+                .map { "\($0.p) : \($0.q)" } ?? "—"
+        }
+
+        private func melodicCents(delta: [Int:Int]) -> Double {
+            ratioFromMonzo(delta)
+                .map { RatioMath.canonicalPQUnit($0.p, $0.q) }
+                .map { RatioMath.centsForRatio($0.p, $0.q) } ?? .nan
         }
 
         private func frequencyDeltaText(


### PR DESCRIPTION
### Motivation
- Fix incorrect Ratio card and "At a glance" values (e.g., 1/1 → 5/4 showing as 5/1 and wrong cents) caused by using raw monzo-derived p/q without folding into the unit octave.

### Description
- Canonicalize `ratioFromMonzo` outputs with `RatioMath.canonicalPQUnit` when building endpoint models in `Tenney/LatticeView.swift` so `RatioCard` numerator/denominator render correctly.
- Use the same unit-canonical ratios for melodic interval text and cents by updating `melodicRatioDisplayText` and `melodicCents`, and pass `melodicRatioText`/`melodicCentsValue` into `DistanceDetailSheet.Model`.
- Align plumbing names and inputs by replacing the editable `referenceHz` with `referenceA4Hz` in the overlay/detail model where applicable.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977ca4556c48327ba4c5faee1767bca)