### PR TITLE
Add data-driven Prime motion map (PrimeMotionDiagram + PrimeLiftStrip) and pass monzoDelta to detail model

### DIFF
--- a/Tenney/LatticeView.swift
+++ b/Tenney/LatticeView.swift
@@ -5879,6 +5879,7 @@ struct LatticeView: View {
                             chips: chips,
                             rows: rows,
                             primeDeltas: primeDeltas,
+                            monzoDelta: delta,
                             endpoints: endpoints,
                             melodicRatioText: melodicRatioText,
                             melodicCentsValue: melodicCentsValue
@@ -5901,6 +5902,7 @@ struct LatticeView: View {
                                         chips: chips,
                                         rows: rows,
                                         primeDeltas: primeDeltas,
+                                        monzoDelta: delta,
                                         endpoints: endpoints,
                                         melodicRatioText: melodicRatioText,
                                         melodicCentsValue: melodicCentsValue
@@ -5949,6 +5951,7 @@ struct LatticeView: View {
             chips: [DistanceDetailSheet.ChipMetric],
             rows: [DistanceDetailSheet.MetricRow],
             primeDeltas: [DistanceDetailSheet.PrimeDelta],
+            monzoDelta: [Int:Int],
             endpoints: (from: DistanceDetailSheet.Endpoint, to: DistanceDetailSheet.Endpoint),
             melodicRatioText: String,
             melodicCentsValue: Double?
@@ -5961,6 +5964,7 @@ struct LatticeView: View {
                 chips: chips,
                 rows: rows,
                 primeDeltas: primeDeltas,
+                monzoDelta: monzoDelta,
                 referenceA4Hz: referenceA4Hz,
                 melodicRatioText: melodicRatioText,
                 melodicCentsValue: melodicCentsValue,


### PR DESCRIPTION
### Motivation
- Provide a richer, data-driven visualization of Monzo deltas inside the Distance detail sheet that shows 3/5 plane motion, higher-prime lift, and a concise human interpretation. 
- Allow the diagram to highlight contributions from tapped prime chips and to display a tooltip / accessibility summary backed by raw monzo data.

### Description
- Add `monzoDelta: [Int:Int]` to `DistanceDetailSheet.Model` and wire it through from `LatticeView.TenneyDistanceOverlay.detailModel(...)` by passing the already-computed `delta` unchanged. 
- Replace the static `PrimeAxisDiagram()` with `PrimeMotionDiagram` (Canvas-based) which draws a dashed integer grid, solid axes, an origin dot, an arrow from (0,0) → (Δe₃, Δe₅), endpoint label `(+e3, −e5)` and a short direction hint (“toward fifths/thirds/diagonal”), animating arrow changes only when `reduceMotion` allows. 
- Add `PrimeLiftStrip` to render a compact horizontal mini-histogram for primes ≥ 7 with bars tinted by `PrimeDelta.tint` and an `Out-of-plane:` footnote computed as `sqrt(sum(|Δeₚ|^2))`. 
- Add chip interaction and state: tapping a chip toggles `highlightedPrime` (3/5 highlight axis components and ghost projection, ≥7 highlight corresponding bar); long-press on the plane shows a tooltip (`popover` on iPad/macOS when available, overlay fallback on iPhone); accessibility label summarizes prime motion and out-of-plane magnitude. 
- Keep all new code `private` to the file, preserve existing chips layout and Tenney math, and add no external dependencies; updated only `Tenney/DistanceDetailSheet.swift` and `Tenney/LatticeView.swift`.

### Testing
- Automated tests: none executed in this environment. 
- Suggested automated/manual sanity checks (not executed here): run `xcodebuild -scheme Tenney -destination 'generic/platform=iOS' build` and `xcodebuild -scheme Tenney -destination 'platform=macOS,variant=Mac Catalyst' build`, then open the lattice, select two nodes and open the Distance detail sheet to verify arrow direction, higher-prime bars, chip highlighting, long-press tooltip, and accessibility label.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977ed57d2e88327886de6c0be4bcc0e)