### PR TITLE
Adjust InfoCard padding for safe-area asymmetry

### DIFF
--- a/Tenney/LatticeView.swift
+++ b/Tenney/LatticeView.swift
@@ -53,6 +53,7 @@ struct LatticeView: View {
 
     @State private var infoCardStaffWidth: CGFloat = 0
     @State private var infoCardHeight: CGFloat = 0
+    @State private var infoCardSafeAreaInfo: InfoCardSafeAreaInfo = .init()
     @State private var chipsHUDHeight: CGFloat = 0
     @State private var activeDistanceDetail: DistanceDetailSheet.Model? = nil
 
@@ -67,6 +68,23 @@ struct LatticeView: View {
         static var defaultValue: CGFloat = 0
         static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
             value = max(value, nextValue())
+        }
+    }
+
+    private struct InfoCardSafeAreaInfo {
+        let size: CGSize
+        let insets: EdgeInsets
+
+        init(size: CGSize = .zero, insets: EdgeInsets = EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)) {
+            self.size = size
+            self.insets = insets
+        }
+    }
+
+    private struct InfoCardSafeAreaKey: PreferenceKey {
+        static var defaultValue: InfoCardSafeAreaInfo = .init()
+        static func reduce(value: inout InfoCardSafeAreaInfo, nextValue: () -> InfoCardSafeAreaInfo) {
+            value = nextValue()
         }
     }
 
@@ -4333,12 +4351,17 @@ struct LatticeView: View {
                 if focusedPoint != nil {
                     infoCard
                         .padding(.top, topPadding)
-                        .padding(.trailing, 12)
+                        .padding(infoCardEdgeInsets(baseLeading: 0, baseTrailing: 12, extra: 14, info: infoCardSafeAreaInfo))
                         .frame(maxWidth: infoCardMaxWidth, alignment: .trailing)
                         .fixedSize(horizontal: false, vertical: true)
                         .background(
                             GeometryReader { proxy in
-                                Color.clear.preference(key: InfoCardHeightKey.self, value: proxy.size.height)
+                                Color.clear
+                                    .preference(key: InfoCardHeightKey.self, value: proxy.size.height)
+                                    .preference(
+                                        key: InfoCardSafeAreaKey.self,
+                                        value: InfoCardSafeAreaInfo(size: proxy.size, insets: proxy.safeAreaInsets)
+                                    )
                             }
                         )
                         // .contentShape(Rectangle())
@@ -4535,6 +4558,7 @@ struct LatticeView: View {
                 }
             }
             .onPreferenceChange(InfoCardHeightKey.self) { infoCardHeight = $0 }
+            .onPreferenceChange(InfoCardSafeAreaKey.self) { infoCardSafeAreaInfo = $0 }
             .onChange(of: app.builderLoadedScale?.id) { id in
                     if id != nil {
                         store.captureLoadedScaleBaseline()
@@ -4577,6 +4601,7 @@ struct LatticeView: View {
         .modifier(LandscapeSideUnsafe(isOn: isPhoneLandscape))
         .onPreferenceChange(ChipsHUDHeightKey.self) { chipsHUDHeight = $0 }
         .onPreferenceChange(InfoCardHeightKey.self) { infoCardHeight = $0 }
+        .onPreferenceChange(InfoCardSafeAreaKey.self) { infoCardSafeAreaInfo = $0 }
         .sheet(item: $activeDistanceDetail) { model in
             distanceDetailSheet(for: model)
         }
@@ -5001,6 +5026,33 @@ struct LatticeView: View {
         .shadow(color: Color.black.opacity(0.18), radius: 22, x: 0, y: 14)
         .shadow(color: Color.black.opacity(0.10), radius: 6,  x: 0, y: 2)
      }
+
+    private func infoCardEdgeInsets(
+        baseLeading: CGFloat,
+        baseTrailing: CGFloat,
+        extra: CGFloat,
+        info: InfoCardSafeAreaInfo
+    ) -> EdgeInsets {
+#if canImport(UIKit)
+        let isPhone = UIDevice.current.userInterfaceIdiom == .phone
+#else
+        let isPhone = false
+#endif
+        let isLandscape = info.size.width > info.size.height
+        let leftInset = info.insets.leading
+        let rightInset = info.insets.trailing
+        let biasRight = isLandscape && rightInset > leftInset + 1
+        let biasLeft = isLandscape && leftInset > rightInset + 1
+        let leadingExtra = (isPhone && biasLeft) ? extra : 0
+        let trailingExtra = (isPhone && biasRight) ? extra : 0
+
+        return EdgeInsets(
+            top: 0,
+            leading: baseLeading + leadingExtra,
+            bottom: 0,
+            trailing: baseTrailing + trailingExtra
+        )
+    }
     
     private struct DrawerGlassButton: View {
         let title: String


### PR DESCRIPTION
### Motivation

- Apply an extra, edge-specific padding bias to the InfoCard when it is shown on iPhone landscape so the card is nudged away from the Dynamic Island side. 
- Keep the change surgical and scoped to the InfoCard callsite to avoid any regressions on iPad, macOS/Catalyst, portrait iPhone, or symmetric-inset landscapes. 

### Description

- Added a small scoped model and preference key `InfoCardSafeAreaInfo` / `InfoCardSafeAreaKey` and a `@State` to store that info in `Tenney/LatticeView.swift` so the InfoCard can observe its own `GeometryProxy.safeAreaInsets` without wrapping global layouts. 
- Captured the info card geometry and safe-area insets from the card’s background `GeometryReader` preference and wired it to `.onPreferenceChange` so the card only updates when visible. 
- Implemented a single reusable helper `infoCardEdgeInsets(baseLeading:baseTrailing:extra:info:)` inside `LatticeView` guarded with `#if canImport(UIKit)` that computes `EdgeInsets` by checking `isPhone`, `isLandscape` (via `info.size.width > info.size.height`) and asymmetric insets rules (`rightInset > leftInset + 1` and `leftInset > rightInset + 1`) and only adds the extra (defaulted to `14`) to the biased edge. 
- Replaced the previous `.padding(.trailing, 12)` at the InfoCard callsite with `.padding(infoCardEdgeInsets(...))`, preserving the existing base padding and scoping the behavior to that single callsite in `Tenney/LatticeView.swift`. 

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977f86becb88327b3bbfa8ee98e7d69)